### PR TITLE
reorganize navigation to use categories

### DIFF
--- a/modules/nav.adoc
+++ b/modules/nav.adoc
@@ -1,31 +1,39 @@
+.Introduction
 * xref:ROOT:index.adoc[What's New]
 * xref:ROOT:getting-started.adoc[Getting Started]
-* Access Control
-** xref:ROOT:authentication.adoc[Authentication]
-** xref:ROOT:authorizing-users.adoc[Authorizing Users]
-** xref:ROOT:data-routing.adoc[Data Routing]
-** xref:ROOT:sync-function-api.adoc[Sync Function API]
-* Operations
-** xref:ROOT:config-properties.adoc[Configuration File]
-** xref:ROOT:command-line-options.adoc[CLI]
-** xref:ROOT:logging.adoc[Logging]
-** xref:ROOT:shared-bucket-access.adoc[Shared Bucket Access]
-** xref:ROOT:server-integration.adoc[Webhooks and Changes Feed]
-** xref:ROOT:resolving-conflicts.adoc[Resolving Conflicts]
-** xref:ROOT:integrating-external-stores.adoc[Integrating External Stores]
-** xref:ROOT:running-replications.adoc[Running Replications]
-** xref:ROOT:rest-api-client.adoc[REST API Client]
-** xref:ROOT:sgcollect-info.adoc[SGCollect Info]
-* Security
-** xref:ROOT:deployment-considerations.adoc[Deployment Considerations]
-** xref:ROOT:configuring-ssl.adoc[Configuring SSL]
-* Deployment
-** xref:ROOT:upgrade.adoc[Upgrade]
-** xref:ROOT:load-balancer.adoc[NGINX]
-** xref:ROOT:database-offline.adoc[Taking Databases Offline and Online]
-** xref:ROOT:os-level-tuning.adoc[OS Level Tuning]
-* References
-** xref:ROOT:rest-api.adoc[Public REST API]
-** xref:ROOT:admin-rest-api.adoc[Admin REST API]
+
+.Access Control
+* xref:ROOT:authentication.adoc[Authentication]
+* xref:ROOT:authorizing-users.adoc[Authorizing Users]
+* xref:ROOT:data-routing.adoc[Data Routing]
+* xref:ROOT:sync-function-api.adoc[Sync Function API]
+
+.Operations
+* xref:ROOT:config-properties.adoc[Configuration File]
+* xref:ROOT:command-line-options.adoc[CLI]
+* xref:ROOT:logging.adoc[Logging]
+* xref:ROOT:shared-bucket-access.adoc[Shared Bucket Access]
+* xref:ROOT:server-integration.adoc[Webhooks and Changes Feed]
+* xref:ROOT:resolving-conflicts.adoc[Resolving Conflicts]
+* xref:ROOT:integrating-external-stores.adoc[Integrating External Stores]
+* xref:ROOT:running-replications.adoc[Running Replications]
+* xref:ROOT:rest-api-client.adoc[REST API Client]
+* xref:ROOT:sgcollect-info.adoc[SGCollect Info]
+
+.Security
+* xref:ROOT:deployment-considerations.adoc[Deployment Considerations]
+* xref:ROOT:configuring-ssl.adoc[Configuring SSL]
+
+.Deployment
+* xref:ROOT:upgrade.adoc[Upgrade]
+* xref:ROOT:load-balancer.adoc[NGINX]
+* xref:ROOT:database-offline.adoc[Taking Databases Offline and Online]
+* xref:ROOT:os-level-tuning.adoc[OS Level Tuning]
+
+.API References
+* xref:ROOT:rest-api.adoc[Public REST API]
+* xref:ROOT:admin-rest-api.adoc[Admin REST API]
+
+.Release Notes & Compatibility
 * xref:ROOT:release-notes.adoc[Release Notes]
 * xref:ROOT:compatibility-matrix.adoc[Compatibility Matrix]


### PR DESCRIPTION
Shift all the navigation up one level to take advantage of the styling of categories in the new docs UI. The following screenshots shows the difference in appearance.

Before:

![before](https://user-images.githubusercontent.com/79351/43889372-38bf16ea-9b81-11e8-9acd-20ea24c947e0.png)

After:

![after](https://user-images.githubusercontent.com/79351/43889374-3bcd4226-9b81-11e8-948c-f37997568cee.png)

The new docs UI expands the top-level categories by default, at least for now.