### PR TITLE
rewrite tabsets to use new structure supported by extension (master)

### DIFF
--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -5,16 +5,17 @@
 :sg_download_link: https://packages.couchbase.com/releases/couchbase-sync-gateway/2.0.0/
 :sg_package_name: couchbase-sync-gateway-community_2.0.0_x86_64
 :sg_accel_package_name: couchbase-sg-accel-centos_enterprise_2.0.0-beta1_x86_64
+:tabs:
 
 == Installation
 
 Install Sync Gateway on the operating system of your choice:
 
-[.tabs]
-=====
-.Ubuntu
-[.tab]
+[{tabs}]
 ====
+Ubuntu::
++
+--
 Download Sync Gateway from the {url-downloads}#couchbase-mobile[Couchbase downloads page] or using `wget`.
 
 [source,bash,subs="attributes"]
@@ -43,9 +44,11 @@ The config file and logs are located in `/home/sync_gateway`.
 
 You can also run the *sync_gateway* binary directly from the command line.
 The binary is installed at `/opt/couchbase-sync-gateway/bin/sync_gateway`.
-====
-.Red Hat/CentOS
-====
+--
+
+Red Hat/CentOS::
++
+--
 Download Sync Gateway from the {url-downloads}#couchbase-mobile[Couchbase downloads page] or using the `wget`.
 
 [source,bash,subs="attributes"]
@@ -90,9 +93,11 @@ systemctl stop sync_gateway
 ----
 
 The config file and logs are located in `/home/sync_gateway`.
-====
-.Debian
-====
+--
+
+Debian::
++
+--
 Download Sync Gateway from the {url-downloads}#couchbase-mobile[Couchbase downloads page] or using the `wget`.
 
 [source,bash,subs="attributes"]
@@ -116,9 +121,11 @@ systemctl stop sync_gateway
 ----
 
 The config file and logs are located in `/home/sync_gateway`.
-====
-.Windows
-====
+--
+
+Windows::
++
+--
 Download Sync Gateway from the {url-downloads}#couchbase-mobile[Couchbase downloads page].
 Open the installer and follow the instructions.
 If the installation was successful you will see the following.
@@ -129,9 +136,11 @@ Sync Gateway runs as a service (reachable on `+http://localhost:4985+`). To stop
 
 * The configuration file is located under *C:FilesGateway.json*.
 * Logs are located under *C:FilesGateway*.
-====
-.macOS
-====
+--
+
+macOS::
++
+--
 Download Sync Gateway from the {url-downloads}#couchbase-mobile[Couchbase downloads page] or using the `wget`.
 
 [source,bash,subs="attributes"]
@@ -172,8 +181,8 @@ $ sudo launchctl unload /Library/LaunchDaemons/com.couchbase.mobile.sync_gateway
 ----
 
 The config file and logs are located in `/Users/sync_gateway`.
+--
 ====
-=====
 
 The following sections describe how to install and configure Sync Gateway to run with Couchbase Server.
 
@@ -213,29 +222,24 @@ image::create-user.png[]
 
 . The steps to create the RBAC user differ slightly depending on the version of Couchbase Server that you have installed. We explain the differences below.
 +
-[.tabs]
-=====
-.Couchbase Server 5.1
-[.tab]
+[{tabs}]
 ====
+Couchbase Server 5.1::
++
 In the pop-up window, provide a *Username* and *Password*, those credentials will be used by Sync Gateway to connect later on.
 Next, you must grant RBAC roles to that user.
 If you are using Couchbase Server 5.1, you must enable the *Bucket Full Access* and *Read Only Admin* roles.
-
++
 image::user-settings.png[]
 
-====
-.Couchbase Server 5.5
-[.tab]
-====
+Couchbase Server 5.5::
++
 In the pop-up window, provide a *Username* and *Password*, those credentials will be used by Sync Gateway to connect later on.
 Next, you must grant RBAC roles to that user.
 If you are using Couchbase Server 5.5, you must enable the *Application Access* and *Read Only Admin* roles.
-
++
 image::user-settings-5-5.png[]
-
 ====
-=====
 
 . If you're installing Couchbase Server on the cloud, make sure that network permissions (or firewall settings) allow incoming connections to Couchbase Server ports.
 In a typical mobile deployment on premise or in the cloud (AWS, RedHat, etc.), the following ports must be opened on the host for Couchbase Server to operate correctly: 8091, 8092, 8093, 8094, 11207, 11210, 11211, 18091, 18092, 18093.


### PR DESCRIPTION
A tabset is defined using a description list (dlist) wrapped in an example block. Each term becomes the tab's title and the blocks attached to the term (aka the details) become the tab's content. (The open block surrounding the attached blocks is optional).

```
[tabs]
====
Tab A::
+
Content for Tab A.

Tab B::
+
--
Content for Tab B.

More content for Tab B.
--
====
```

We annotated the block as follows to avoid warnings when the block extension is not registered (such as in a preview tool).

```
:tabs:

[{tabs}]
====
....
====
```