### PR TITLE
Reverse "use_views" bool values in compatibility matrix

### DIFF
--- a/modules/ROOT/pages/compatibility-matrix.adoc
+++ b/modules/ROOT/pages/compatibility-matrix.adoc
@@ -86,7 +86,7 @@ The table below summarizes the compatible versions of Sync Gateway with Couchbas
 
 `shared_bucket_access: false`
 
-`use_views: false`
+`use_views: true`
 |✔
 |✔
 |✔
@@ -108,7 +108,7 @@ The table below summarizes the compatible versions of Sync Gateway with Couchbas
 
 |2.1
 
-`use_views: true`
+`use_views: false`
 |✖
 |✖
 |✖


### PR DESCRIPTION
`use_views: false` is only compatible with >=5.5
`use_views: true` is compatible with all current versions

I've reversed the values in the compatibility matrix to correct this.