### PR TITLE
Add send_www_authenticate_header config option

### DIFF
--- a/modules/ROOT/assets/attachments/sg.yaml
+++ b/modules/ROOT/assets/attachments/sg.yaml
@@ -365,6 +365,10 @@ properties:
                     description: The list of channels this role is automatically granted access to when Sync Gateway starts.
                     items:
                       type: string
+          send_www_authenticate_header:
+            type: boolean
+            description: Whether to send WWW-Authenticate header in 401 responses.
+            default: true
           server:
             type: string
             description: |

--- a/modules/ROOT/assets/attachments/sg.yaml
+++ b/modules/ROOT/assets/attachments/sg.yaml
@@ -368,7 +368,7 @@ properties:
           send_www_authenticate_header:
             type: boolean
             description: Whether to send WWW-Authenticate header in 401 responses.
-            default: true
+            default: 'true'
           server:
             type: string
             description: |


### PR DESCRIPTION
This config option was added in 2.1.0 by a community contribution: https://github.com/couchbase/sync_gateway/pull/3408