### PR TITLE
DOC-2920 - hit ratio derived stats

### DIFF
--- a/modules/ROOT/pages/stats-monitoring.adoc
+++ b/modules/ROOT/pages/stats-monitoring.adoc
@@ -243,6 +243,8 @@ The number of active revisions in the channel cache.
 
 Channel cache requests fully served by the cache.
 
+Channel Cache Hit Ratio = `chan_cache_hits` / (`chan_cache_hits` + `chan_cache_misses`)
+
 ===== chan_cache_max_entries
 
 Size of the largest channel cache.
@@ -252,6 +254,8 @@ Helps with channel cache tuning, and as a hint on cache size variation (when com
 ===== chan_cache_misses
 
 Channel cache requests not fully served by the cache.
+
+Channel Cache Hit Ratio = `chan_cache_hits` / (`chan_cache_hits` + `chan_cache_misses`)
 
 ===== chan_cache_num_channels
 
@@ -283,9 +287,13 @@ Helps with channel cache tuning, and as a hint on cache size variation (when com
 
 Revision cache hits.
 
+Rev Cache Hit Ratio = `rev_cache_hits` / (`rev_cache_hits` + `rev_cache_misses`)
+
 ===== rev_cache_misses
 
 Revision cache misses.
+
+Rev Cache Hit Ratio = `rev_cache_hits` / (`rev_cache_hits` + `rev_cache_misses`)
 
 ==== cbl_replication_pull
 


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-2920

[Row 21 and 22](https://docs.google.com/spreadsheets/d/1aZjCIwwZYrUSaQCK63QUg7_jrbo0jJcsxPoXG2Q4s0o/edit#gid=0) give a definition of channel and rev cache hit ratio.

@adamcfraser @bbrks I am wondering if we should add a link to the config props that play a part in the hit ratio. Can you remind me which one it is?