### PR TITLE
DOC-2920 - gsi view/query stats

### DIFF
--- a/modules/ROOT/pages/stats-monitoring.adoc
+++ b/modules/ROOT/pages/stats-monitoring.adoc
@@ -99,6 +99,17 @@ The response is a JSON object with the following schema.
           "{xref-cb-config}num_access_errors[num_access_errors]": 0,
           "{xref-cb-config}num_docs_rejected[num_docs_rejected]": 0,
           "{xref-cb-config}total_auth_time[total_auth_time]": 0
+        },
+        "??": {
+          "channels_count": 0,
+          "access_count": 0,
+          "roleAccess_count": 0,
+          "allDocs_count": 0,
+          "principals_count": 0,
+          "resync_count": 0,
+          "sequences_count": 0,
+          "sessions_count": 0,
+          "tombstones_count": 0
         }
       }
     },


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-2920

[Row 87 to 91](https://docs.google.com/spreadsheets/d/1aZjCIwwZYrUSaQCK63QUg7_jrbo0jJcsxPoXG2Q4s0o/edit#gid=0) mention a few stats in the "Underlying Stats" column (also in this PR). However I could not see them in the [sample output](https://gist.github.com/jamiltz/261589296daa6fcb1022fe67520a90d2) I'm using.

@adamcfraser @bbrks Are those returned by default?