### PR TITLE
DOC-2929 - sequence values as integer or dictionary

### DIFF
--- a/modules/ROOT/assets/attachments/sync-gateway-admin.yaml
+++ b/modules/ROOT/assets/attachments/sync-gateway-admin.yaml
@@ -265,7 +265,7 @@ parameters:
   since:
     in: query
     name: since
-    description: Starts the results from the change immediately after the given sequence ID. Sequence IDs can be integer or dictionary types and should be considered opaque; they come from the last_seq property of a prior response.
+    description: Starts the results from the change immediately after the given sequence ID. Sequence IDs should be considered opaque; they come from the last_seq property of a prior response.
     type: integer
     required: false
   style:
@@ -351,7 +351,7 @@ parameters:
           type: string
           default: 'normal'
         since:
-          description: Starts the results from the change immediately after the given sequence ID. Sequence IDs can be integer or dictionary types and should be considered opaque; they come from the last_seq property of a prior response.
+          description: Starts the results from the change immediately after the given sequence ID. Sequence IDs should be considered opaque; they come from the last_seq property of a prior response.
           type: object
         heartbeat:
           description: Default is 0. Interval in milliseconds at which an empty line (CRLF) is written to the response. This helps prevent gateways from deciding the socket is idle and closing it. Only applicable to longpoll or continuous feeds. Overrides any timeout to keep the feed alive indefinitely. Setting to 0 results in no heartbeat.

--- a/modules/ROOT/assets/attachments/sync-gateway-admin.yaml
+++ b/modules/ROOT/assets/attachments/sync-gateway-admin.yaml
@@ -265,7 +265,7 @@ parameters:
   since:
     in: query
     name: since
-    description: Starts the results from the change immediately after the given sequence ID. Sequence IDs should be considered opaque; they come from the last_seq property of a prior response.
+    description: Starts the results from the change immediately after the given sequence ID. Sequence IDs can be integer or dictionary types and should be considered opaque; they come from the last_seq property of a prior response.
     type: integer
     required: false
   style:
@@ -351,8 +351,8 @@ parameters:
           type: string
           default: 'normal'
         since:
-          description: Starts the results from the change immediately after the given sequence ID. Sequence IDs should be considered opaque; they come from the last_seq property of a prior response.
-          type: integer
+          description: Starts the results from the change immediately after the given sequence ID. Sequence IDs can be integer or dictionary types and should be considered opaque; they come from the last_seq property of a prior response.
+          type: object
         heartbeat:
           description: Default is 0. Interval in milliseconds at which an empty line (CRLF) is written to the response. This helps prevent gateways from deciding the socket is idle and closing it. Only applicable to longpoll or continuous feeds. Overrides any timeout to keep the feed alive indefinitely. Setting to 0 results in no heartbeat.
           type: integer
@@ -2432,7 +2432,7 @@ definitions:
     type: object
     properties:
       last_seq:
-        type: integer
+        type: object
         description: Last change sequence number
       results:
         type: array

--- a/modules/ROOT/assets/attachments/sync-gateway-public.yaml
+++ b/modules/ROOT/assets/attachments/sync-gateway-public.yaml
@@ -266,7 +266,7 @@ parameters:
   since:
     in: query
     name: since
-    description: Starts the results from the change immediately after the given sequence ID. Sequence IDs can be integer or dictionary types and should be considered opaque; they come from the last_seq property of a prior response.
+    description: Starts the results from the change immediately after the given sequence ID. Sequence IDs should be considered opaque; they come from the last_seq property of a prior response.
     type: object
     required: false
   style:
@@ -352,7 +352,7 @@ parameters:
           type: string
           default: 'normal'
         since:
-          description: Starts the results from the change immediately after the given sequence ID. Sequence IDs can be integer or dictionary types and should be considered opaque; they come from the last_seq property of a prior response.
+          description: Starts the results from the change immediately after the given sequence ID. Sequence IDs should be considered opaque; they come from the last_seq property of a prior response.
           type: object
         heartbeat:
           description: Default is 0. Interval in milliseconds at which an empty line (CRLF) is written to the response. This helps prevent gateways from deciding the socket is idle and closing it. Only applicable to longpoll or continuous feeds. Overrides any timeout to keep the feed alive indefinitely. Setting to 0 results in no heartbeat.

--- a/modules/ROOT/assets/attachments/sync-gateway-public.yaml
+++ b/modules/ROOT/assets/attachments/sync-gateway-public.yaml
@@ -266,8 +266,8 @@ parameters:
   since:
     in: query
     name: since
-    description: Starts the results from the change immediately after the given sequence ID. Sequence IDs should be considered opaque; they come from the last_seq property of a prior response.
-    type: integer
+    description: Starts the results from the change immediately after the given sequence ID. Sequence IDs can be integer or dictionary types and should be considered opaque; they come from the last_seq property of a prior response.
+    type: object
     required: false
   style:
     in: query
@@ -352,8 +352,8 @@ parameters:
           type: string
           default: 'normal'
         since:
-          description: Starts the results from the change immediately after the given sequence ID. Sequence IDs should be considered opaque; they come from the last_seq property of a prior response.
-          type: integer
+          description: Starts the results from the change immediately after the given sequence ID. Sequence IDs can be integer or dictionary types and should be considered opaque; they come from the last_seq property of a prior response.
+          type: object
         heartbeat:
           description: Default is 0. Interval in milliseconds at which an empty line (CRLF) is written to the response. This helps prevent gateways from deciding the socket is idle and closing it. Only applicable to longpoll or continuous feeds. Overrides any timeout to keep the feed alive indefinitely. Setting to 0 results in no heartbeat.
           type: integer
@@ -1433,7 +1433,7 @@ definitions:
     type: object
     properties:
       last_seq:
-        type: integer
+        type: object
         description: Last change sequence number
       results:
         type: array


### PR DESCRIPTION
document `since` and `last_seq` values as integer or dictionary

https://issues.couchbase.com/browse/DOC-2929

@adamcfraser @bbrks I'm not sure this is correct, would you mind providing a review? The JIRA issue talks about JSON values, I assume that's a dictionary (`type: object` in the OpenAPI spec)