### PR TITLE
DOC-4726 - POST `/{db}/_google` endpoint

### DIFF
--- a/modules/ROOT/assets/attachments/sg.yaml
+++ b/modules/ROOT/assets/attachments/sg.yaml
@@ -565,6 +565,17 @@ properties:
         description: Whether the Facebook Login server will register new user accounts.
         type: boolean
         default: 'false'
+  google:
+    description: Configuration for Google Login authentication.
+    type: object
+    properties:
+      register:
+        description: Whether the Google Login server will register new user accounts.
+        type: boolean
+        default: 'false'
+      app_client_id:
+        description: The Google App Client ID.
+        type: string
   interface:
     description: Public REST API port.
     type: string

--- a/modules/ROOT/assets/attachments/sync-gateway-public.yaml
+++ b/modules/ROOT/assets/attachments/sync-gateway-public.yaml
@@ -1020,7 +1020,7 @@ paths:
       summary: User creation / authentication via Google
       description: |
         Sync Gateway allows users to authenticate using a Google account. Your application is responsible for generating a Google token; this generally needs to be done by running the Google login flow inside a web-view and capturing the generated token. This endpoint can be used to check the validity of the access token.
-        To allow Google Login with Sync Gateway, it must be explicitely enabled in the Sync Gateway configuration file by setting the [google.register](config-properties.html#google-register) property to `true`.
+        To allow Google Login with Sync Gateway, it must be explicitly enabled in the Sync Gateway configuration file by setting the [google.register](config-properties.html#google-register) property to `true` and setting the [google.app_client_id](config-properties.html#google-app_client_id) property with a Google app client ID.
       parameters:
         - in: body
           name: body

--- a/modules/ROOT/assets/attachments/sync-gateway-public.yaml
+++ b/modules/ROOT/assets/attachments/sync-gateway-public.yaml
@@ -1020,7 +1020,7 @@ paths:
       summary: User creation / authentication via Google
       description: |
         Sync Gateway allows users to authenticate using a Google account. Your application is responsible for generating a Google token; this generally needs to be done by running the Google login flow inside a web-view and capturing the generated token. This endpoint can be used to check the validity of the access token.
-        To allow Google Login with Sync Gateway, it must be explicitely enabled in the Sync Gateway configuration file by setting the [google.register](config-properties.html#facebook-register) property to `true`.
+        To allow Google Login with Sync Gateway, it must be explicitely enabled in the Sync Gateway configuration file by setting the [google.register](config-properties.html#google-register) property to `true`.
       parameters:
         - in: body
           name: body
@@ -1028,7 +1028,7 @@ paths:
           schema:
             type: object
             properties:
-              access_token:
+              id_token:
                 type: string
                 decription: The access token for the user to authenticate
           responses:
@@ -1046,7 +1046,7 @@ paths:
                 userCtx:
                   $ref: '#/definitions/UserContext'
             401:
-              description: Authentication failed. Facebook verification server status 400
+              description: Authentication failed. Google verification server status 400
   /{db}/_revs_diff:
     parameters:
     - $ref: '#/parameters/db'

--- a/modules/ROOT/assets/attachments/sync-gateway-public.yaml
+++ b/modules/ROOT/assets/attachments/sync-gateway-public.yaml
@@ -1011,6 +1011,42 @@ paths:
                   $ref: '#/definitions/UserContext'
             401:
               description: Authentication failed. Facebook verification server status 400
+  /{db}/_google:
+    parameters:
+      - $ref: '#/parameters/db'
+    post:
+      tags:
+        - auth
+      summary: User creation / authentication via Google
+      description: |
+        Sync Gateway allows users to authenticate using a Google account. Your application is responsible for generating a Google token; this generally needs to be done by running the Google login flow inside a web-view and capturing the generated token. This endpoint can be used to check the validity of the access token.
+        To allow Google Login with Sync Gateway, it must be explicitely enabled in the Sync Gateway configuration file by setting the [google.register](config-properties.html#facebook-register) property to `true`.
+      parameters:
+        - in: body
+          name: body
+          description: Request body
+          schema:
+            type: object
+            properties:
+              access_token:
+                type: string
+                decription: The access token for the user to authenticate
+          responses:
+            200:
+              description: The request was successful
+              schema:
+                authentication_handlers:
+                  type: array
+                  description: List of authentication methods.
+                  items:
+                    type: string
+                ok:
+                  type: boolean
+                  description: Always true if the operation was successful.
+                userCtx:
+                  $ref: '#/definitions/UserContext'
+            401:
+              description: Authentication failed. Facebook verification server status 400
   /{db}/_revs_diff:
     parameters:
     - $ref: '#/parameters/db'


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-4726

@bbrks This PR needs your review. I've basically copy-pasted the `/{db}/_facebook` endpoint and replaced `facebook` with `google` so there may well be other modifications to make.

In particular, I'm not sure whether the `google.register` property exists in the config? If so I'll update the config file too.