### PR TITLE
DOC-4726 - review `register` property

### DIFF
--- a/modules/ROOT/assets/attachments/sg.yaml
+++ b/modules/ROOT/assets/attachments/sg.yaml
@@ -562,7 +562,7 @@ properties:
     type: object
     properties:
       register:
-        description: Whether the `POST /{db}/_facebook` endpoint should register a user if one doesn't already exist.
+        description: Whether the `POST /{db}/_facebook` endpoint should register a user if one doesn't already exist. The email returned by Facebook is used to determine if that user already exists in Sync Gateway.
         type: boolean
         default: 'false'
   google:
@@ -570,7 +570,7 @@ properties:
     type: object
     properties:
       register:
-        description: Whether the `POST /{db}/_google` endpoint should register a user if one doesn't already exist.
+        description: Whether the `POST /{db}/_google` endpoint should register a user if one doesn't already exist. The username and email returned by Google are used to determine if that user already exists in Sync Gateway.
         type: boolean
         default: 'false'
       app_client_id:

--- a/modules/ROOT/assets/attachments/sg.yaml
+++ b/modules/ROOT/assets/attachments/sg.yaml
@@ -562,7 +562,7 @@ properties:
     type: object
     properties:
       register:
-        description: Whether the Facebook Login server will register new user accounts.
+        description: Whether the `POST /{db}/_facebook` endpoint should register a user if one doesn't already exist.
         type: boolean
         default: 'false'
   google:
@@ -570,7 +570,7 @@ properties:
     type: object
     properties:
       register:
-        description: Whether the Google Login server will register new user accounts.
+        description: Whether the `POST /{db}/_google` endpoint should register a user if one doesn't already exist.
         type: boolean
         default: 'false'
       app_client_id:


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-4726

@bbrks I have a follow-up PR here to have a bit more info for `register` properties. I hope that change is accurate.

One bit missing might be to write down how Sync Gateway works out if a user with that `id_token`/`access_token` already exists in SG or is a new user?