### PR TITLE
import filter in getting started

### DIFF
--- a/modules/ROOT/examples/getting-started/sync-gateway-config-import-filter.json
+++ b/modules/ROOT/examples/getting-started/sync-gateway-config-import-filter.json
@@ -1,0 +1,29 @@
+{
+  "log": ["*"],
+  "databases": {
+    "getting-started-db": {
+      "server": "http://localhost:8091",
+      "bucket": "getting-started-bucket",
+      "username": "sync_gateway", // <1>
+      "password": "password", // <2>
+      "enable_shared_bucket_access": true, // <3>
+      "import_docs": "continuous",
+      "num_index_replicas": 0, // <4>
+      "import_filter": `
+        function(doc) { // <5>
+          if (doc.type != "mobile") {
+            return false
+          }
+          return true
+        }`,
+      "users": {
+        "GUEST": { "disabled": false, "admin_channels": ["*"] }
+      },
+      "sync": `function (doc, oldDoc) {
+        if (doc.sdk) {
+          channel(doc.sdk);
+        }
+      }`,
+    }
+  }
+}

--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -477,19 +477,43 @@ The following steps explain how to connect Sync Gateway to the Couchbase Server 
 
 * Open a new file called *sync-gateway-config.json* with the following.
 +
+[{tabs}]
+====
+Default::
++
+--
 [source,javascript]
 ----
 include::{examplesdir}/getting-started/sync-gateway-config.json[]
 ----
-+
-This configuration contains important properties:
-+
+Configuration properties:
+
 <1> The user's username that you created on the Couchbase Server Admin Console.
 <2> The user's password that you created on the Couchbase Server Admin Console.
 <3> The xref:shared-bucket-access.adoc[shared bucket access] feature allows Couchbase Server SDKs to also perform operations on this bucket.
 <4> `num_index_replicas` is the number of index replicas stored in Couchbase Server, introduced with xref:indexing.adoc[GSI/N1QL indexing].
 If you're running a single Couchbase Server node for development purposes the `num_index_replicas` must be set to `0`.
+--
+
+With Import Filter::
 +
+--
+For clusters with a large amount of data, the initial import process can take considerable time to complete.
+Therefore, to get started with a cluster which contains a large number of pre-existing documents, we recommend to use an `import_filter` to reduce the initial import processing time.
+[source,javascript]
+----
+include::{examplesdir}/getting-started/sync-gateway-config-import-filter.json[]
+----
+Configuration properties:
+
+<1> The user's username that you created on the Couchbase Server Admin Console.
+<2> The user's password that you created on the Couchbase Server Admin Console.
+<3> The xref:shared-bucket-access.adoc[shared bucket access] feature allows Couchbase Server SDKs to also perform operations on this bucket.
+<4> `num_index_replicas` is the number of index replicas stored in Couchbase Server, introduced with xref:indexing.adoc[GSI/N1QL indexing].
+If you're running a single Couchbase Server node for development purposes the `num_index_replicas` must be set to `0`.
+<5> Only import documents which have a `type` property equal to `mobile`.
+--
+====
 * Start Sync Gateway from the command line, or if Sync Gateway is running in a service replace the configuration file and restart the service.
 +
 [source,bash]


### PR DESCRIPTION
@rajagp This PR adds tabs in the [getting started](https://docs.couchbase.com/sync-gateway/2.6/getting-started.html#configure-sync-gateway) with the current config as the default option, but with the addition of a config that contains an import filter. To help readers which have an existing cluster with a large amount of documents. Do you think it would help? (cc @djpongh)