### PR TITLE
add missing quotes

### DIFF
--- a/modules/ROOT/assets/attachments/sg.yaml
+++ b/modules/ROOT/assets/attachments/sg.yaml
@@ -145,7 +145,7 @@ properties:
               This property works in conjunction with the [enable_shared_bucket_access](#databases-foo_db-enable_shared_bucket_access) property. When **shared bucket access** is enabled, setting this property to true (`"import_docs": true`) indicates that this Sync Gateway node should perform import processing.
 
               `enable_shared_bucket_access` needs to be `true` on all nodes participating in such a configuration where as `import_docs` can only be set to `true` on a single node.
-            default: false
+            default: 'false'
           cacertpath:
             type: string
             description: |


### PR DESCRIPTION
@adamcfraser @bbrks @sarathkumarsivan although this is only a syntax change, could you confirm if the default value of `import_docs` is indeed `false` in 2.6 and will be `true` in 2.7?