### PR TITLE
Update OS version Deprecation period

### DIFF
--- a/modules/ROOT/pages/supported-os.adoc
+++ b/modules/ROOT/pages/supported-os.adoc
@@ -62,7 +62,7 @@ Nodes in a Sync Gateway cluster should all be running on the same OS, and every 
 
 == Deprecated Versions
 
-Support for deprecated Operated Systems will be removed two releases following the deprecation notice.
+Support for deprecated Operated Systems will be removed four releases following the deprecation notice.
 
 .Deprecated Operating Systems
 [cols="100,135",options="header"]


### PR DESCRIPTION
Extended the deprecation period from 2 releases to 4 releases to give sufficient time for customers to migrate with our new release schedule.