### PR TITLE
DOC-5782 - replace swagger spec links

### DIFF
--- a/modules/ROOT/pages/integrating-external-stores.adoc
+++ b/modules/ROOT/pages/integrating-external-stores.adoc
@@ -62,7 +62,7 @@ var api = 'http://localhost:8000/movies'
   , db = 'movies_lister';
 
 var client = new Swagger({
-  url: 'http://developer.couchbase.com/mobile/swagger/sync-gateway-admin/spec.json',
+  url: 'https://docs.couchbase.com/sync-gateway/current/_attachments/sync-gateway-public.yaml',
   usePromise: true
 }).then(function (client) {
   var data = [];
@@ -160,7 +160,7 @@ var api = 'http://localhost:8000/movies'
   , db = 'movies_lister';
 
 var client = new Swagger({
-  url: 'http://developer.couchbase.com/mobile/swagger/sync-gateway-admin/spec.json',
+  url: 'https://docs.couchbase.com/sync-gateway/current/_attachments/sync-gateway-admin.yaml',
   success: function () {
 
     // 1
@@ -251,7 +251,7 @@ var api = 'http://localhost:8000/movies'
 var movies = [];
 
 var client = new Swagger({
-  url: 'http://developer.couchbase.com/mobile/swagger/sync-gateway-admin/spec.json',
+  url: 'https://docs.couchbase.com/sync-gateway/current/_attachments/sync-gateway-admin.yaml',
   usePromise: true
 }).then(function (client) {
   // Get movies from stub API

--- a/modules/ROOT/pages/integrating-external-stores.adoc
+++ b/modules/ROOT/pages/integrating-external-stores.adoc
@@ -35,6 +35,11 @@ Takes one movie as the request body and updates the item with the same `_id` in 
 
 The Sync Gateway Swagger JS library is a handy tool to send HTTP requests without having to write your own HTTP API wrapper.
 It relies on the Couchbase Mobile Swagger specs.
+
+NOTE: We do not guarantee that the swagger spec will be aligned with the latest version of the REST API.
+The REST API must be considered as the source of truth and in case of any deviations, the REST API will override the swagger spec.
+So please consider the spec as a starting point and make any relevant changes as needed to ensure that it is in conformance with the REST API.
+
 In this case, you will use the xref:admin-rest-api.adoc[Admin REST API spec].
 In the same directory, install the following dependencies.
 

--- a/modules/ROOT/pages/rest-api-client.adoc
+++ b/modules/ROOT/pages/rest-api-client.adoc
@@ -82,7 +82,7 @@ Next, create a new file called *index.js* to start sending requests to Sync Gate
 ----
 // initialize swagger client, point to a swagger spec
 window.client = new SwaggerClient({
-  url: 'http://developer.couchbase.com/mobile/swagger/sync-gateway-public/spec.json',
+  url: 'https://docs.couchbase.com/sync-gateway/current/_attachments/sync-gateway-public.yaml',
   usePromise: true
 })
   .then(function (client) {

--- a/modules/ROOT/pages/rest-api-client.adoc
+++ b/modules/ROOT/pages/rest-api-client.adoc
@@ -7,6 +7,10 @@ Whether you're developing a web application getting data from the Sync Gateway A
 The documentation for the Sync Gateway REST APIs is using Swagger which is a great toolkit for writing REST API documentation, and also to generate HTTP libraries.
 This guide will walk you through how to start using those libraries to display documents stored in Sync Gateway on a web page
 
+NOTE: We do not guarantee that the swagger spec will be aligned with the latest version of the REST API.
+The REST API must be considered as the source of truth and in case of any deviations, the REST API will override the swagger spec.
+So please consider the spec as a starting point and make any relevant changes as needed to ensure that it is in conformance with the REST API.
+
 Follow the steps below to get Sync Gateway up and running.
 
 . {url-downloads}#couchbase-mobile[Download Sync Gateway]


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-5782

Changes:

- replace old swagger refs (.json extension) with docs.couchbase.com links (.yaml extension)

Swagger specs are only published as yaml currently.
It looks like it should also work loading from a yaml spec (swagger-js example https://github.com/swagger-api/swagger-js/blob/2.x/test/client.js#L547-L551)

Keeping open to investigate and resolve.