### PR TITLE
DOC-3837 - Note the requirement for back-ticks with the Sync Function

### DIFF
--- a/modules/ROOT/examples/getting-started/sync-gateway-config-import-filter.json
+++ b/modules/ROOT/examples/getting-started/sync-gateway-config-import-filter.json
@@ -19,7 +19,7 @@
       "users": {
         "GUEST": { "disabled": false, "admin_channels": ["*"] }
       },
-      "sync": `function (doc, oldDoc) {
+      "sync": `function (doc, oldDoc) { // <6>
         if (doc.sdk) {
           channel(doc.sdk);
         }

--- a/modules/ROOT/examples/getting-started/sync-gateway-config.json
+++ b/modules/ROOT/examples/getting-started/sync-gateway-config.json
@@ -12,7 +12,7 @@
       "users": {
         "GUEST": { "disabled": false, "admin_channels": ["*"] }
       },
-      "sync": `function (doc, oldDoc) {
+      "sync": `function (doc, oldDoc) { // <5>
         if (doc.sdk) {
           channel(doc.sdk);
         }

--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -494,7 +494,7 @@ Configuration properties:
 <4> `num_index_replicas` is the number of index replicas stored in Couchbase Server, introduced with xref:indexing.adoc[GSI/N1QL indexing].
 If you're running a single Couchbase Server node for development purposes the `num_index_replicas` must be set to `0`.
 <5> If the document body contains the `sdk` property, route it to a channel called `doc.sdk`, this feature is introduced in xref:sync-gateway-channels.adoc[Access Control].
-The sync function can be surrounded with backticks (+`+) or with standard JSON double quotes, but in that case new lines must be escaped (`\n`).
+The Sync Function can be surrounded with backticks (+`+) to allow multiple lines to be used; or with standard JSON double quotes, in which case new lines must be escaped (`\n`).
 --
 
 With Import Filter::
@@ -514,9 +514,9 @@ Configuration properties:
 <4> `num_index_replicas` is the number of index replicas stored in Couchbase Server, introduced with xref:indexing.adoc[GSI/N1QL indexing].
 If you're running a single Couchbase Server node for development purposes the `num_index_replicas` must be set to `0`.
 <5> Only import documents which have a `type` property equal to `mobile`.
-The import filter function can be surrounded with backticks (+`+) or with standard JSON double quotes, but in that case new lines must be escaped (`\n`).
+The import filter function can be surrounded with backticks (+`+) to allow multiple lines to be used; or with standard JSON double quotes, in which case new lines must be escaped (`\n`).
 <6> If the document body contains the `sdk` property, route it to a channel called `doc.sdk`, this feature is introduced in xref:sync-gateway-channels.adoc[Access Control].
-The sync function can be surrounded with backticks (+`+) or with standard JSON double quotes, but in that case new lines must be escaped (`\n`).
+The Sync Function can be surrounded with backticks (+`+) in the configuration file (xref::getting-started.adoc#configure-sync-gateway[example])to allow multiple lines to be used; or with standard JSON double quotes, in which case new lines must be escaped (`\n`).
 --
 ====
 * Start Sync Gateway from the command line, or if Sync Gateway is running in a service replace the configuration file and restart the service.

--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -494,6 +494,7 @@ Configuration properties:
 <4> `num_index_replicas` is the number of index replicas stored in Couchbase Server, introduced with xref:indexing.adoc[GSI/N1QL indexing].
 If you're running a single Couchbase Server node for development purposes the `num_index_replicas` must be set to `0`.
 <5> If the document body contains the `sdk` property, route it to a channel called `doc.sdk`, this feature is introduced in xref:sync-gateway-channels.adoc[Access Control].
+The sync function can be surrounded with backticks (+`+) or with standard JSON double quotes, but in that case new lines must be escaped (`\n`).
 --
 
 With Import Filter::
@@ -513,7 +514,9 @@ Configuration properties:
 <4> `num_index_replicas` is the number of index replicas stored in Couchbase Server, introduced with xref:indexing.adoc[GSI/N1QL indexing].
 If you're running a single Couchbase Server node for development purposes the `num_index_replicas` must be set to `0`.
 <5> Only import documents which have a `type` property equal to `mobile`.
+The import filter function can be surrounded with backticks (+`+) or with standard JSON double quotes, but in that case new lines must be escaped (`\n`).
 <6> If the document body contains the `sdk` property, route it to a channel called `doc.sdk`, this feature is introduced in xref:sync-gateway-channels.adoc[Access Control].
+The sync function can be surrounded with backticks (+`+) or with standard JSON double quotes, but in that case new lines must be escaped (`\n`).
 --
 ====
 * Start Sync Gateway from the command line, or if Sync Gateway is running in a service replace the configuration file and restart the service.

--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -493,6 +493,7 @@ Configuration properties:
 <3> The xref:shared-bucket-access.adoc[shared bucket access] feature allows Couchbase Server SDKs to also perform operations on this bucket.
 <4> `num_index_replicas` is the number of index replicas stored in Couchbase Server, introduced with xref:indexing.adoc[GSI/N1QL indexing].
 If you're running a single Couchbase Server node for development purposes the `num_index_replicas` must be set to `0`.
+<5> If the document body contains the `sdk` property, route it to a channel called `doc.sdk`, this feature is introduced in xref:sync-gateway-channels.adoc[Access Control].
 --
 
 With Import Filter::
@@ -512,6 +513,7 @@ Configuration properties:
 <4> `num_index_replicas` is the number of index replicas stored in Couchbase Server, introduced with xref:indexing.adoc[GSI/N1QL indexing].
 If you're running a single Couchbase Server node for development purposes the `num_index_replicas` must be set to `0`.
 <5> Only import documents which have a `type` property equal to `mobile`.
+<6> If the document body contains the `sdk` property, route it to a channel called `doc.sdk`, this feature is introduced in xref:sync-gateway-channels.adoc[Access Control].
 --
 ====
 * Start Sync Gateway from the command line, or if Sync Gateway is running in a service replace the configuration file and restart the service.

--- a/modules/ROOT/pages/sync-function.adoc
+++ b/modules/ROOT/pages/sync-function.adoc
@@ -33,6 +33,7 @@ function (doc, oldDoc) {
     // Your code here
 }
 ----
+The Sync Function must be written with backticks (+`+) in the configuration file (xref::getting-started.adoc#configure-sync-gateway[one example]).
 
 The sync function arguments are:
 

--- a/modules/ROOT/pages/sync-function.adoc
+++ b/modules/ROOT/pages/sync-function.adoc
@@ -33,7 +33,7 @@ function (doc, oldDoc) {
     // Your code here
 }
 ----
-The Sync Function must be written with backticks (+`+) in the configuration file (xref::getting-started.adoc#configure-sync-gateway[one example]).
+The Sync Function can be surrounded with backticks (+`+) in the configuration file (xref::getting-started.adoc#configure-sync-gateway[example]) or with standard JSON double quotes, but in that case new lines must be escaped (`\n`).
 
 The sync function arguments are:
 

--- a/modules/ROOT/pages/sync-gateway-channels.adoc
+++ b/modules/ROOT/pages/sync-gateway-channels.adoc
@@ -28,7 +28,7 @@ function (doc, oldDoc) {
   channel("foo");
 }
 ----
-The Sync Function must be surrounded with backticks (+`+) in the configuration file (xref::getting-started.adoc#configure-sync-gateway[one example]).
+The Sync Function can be surrounded with backticks (+`+) in the configuration file (xref::getting-started.adoc#configure-sync-gateway[example]) or with standard JSON double quotes, but in that case new lines must be escaped (`\n`).
 
 Channels come into existence as documents are assigned to them.
 The Sync Function cannot reference any external state and must return the same results every time it's called on the same input.

--- a/modules/ROOT/pages/sync-gateway-channels.adoc
+++ b/modules/ROOT/pages/sync-gateway-channels.adoc
@@ -28,6 +28,7 @@ function (doc, oldDoc) {
   channel("foo");
 }
 ----
+The Sync Function must be surrounded with backticks (+`+) in the configuration file (xref::getting-started.adoc#configure-sync-gateway[one example]).
 
 Channels come into existence as documents are assigned to them.
 The Sync Function cannot reference any external state and must return the same results every time it's called on the same input.

--- a/modules/ROOT/pages/sync-gateway-channels.adoc
+++ b/modules/ROOT/pages/sync-gateway-channels.adoc
@@ -28,7 +28,7 @@ function (doc, oldDoc) {
   channel("foo");
 }
 ----
-The Sync Function can be surrounded with backticks (+`+) in the configuration file (xref::getting-started.adoc#configure-sync-gateway[example]) or with standard JSON double quotes, but in that case new lines must be escaped (`\n`).
+The Sync Function can be surrounded with backticks (+`+) in the configuration file (xref::getting-started.adoc#configure-sync-gateway[example])to allow multiple lines to be used; or with standard JSON double quotes, in which case new lines must be escaped (`\n`).
 
 Channels come into existence as documents are assigned to them.
 The Sync Function cannot reference any external state and must return the same results every time it's called on the same input.


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-3837

Adding the backticks to code blocks is more precise (syntax-wise) but that means we lose the code block syntax highlighting.

Alternatively we can add a sentence immediately below the code block to remind the user to have back-ticks.