### PR TITLE
Update log key reference for 2.6.0

### DIFF
--- a/modules/ROOT/assets/attachments/sg.yaml
+++ b/modules/ROOT/assets/attachments/sg.yaml
@@ -757,7 +757,6 @@ properties:
 
               - `Admin`: Admin processes in Sync Gateway.
               - `Access`: Anytime an `access()` call is made in the sync function.
-              - `Attach`: Attachment processing.
               - `Auth`: Authentication.
               - `Bucket`: Sync Gateway interactions with the bucket (`trace` level only).
               - `Cache`: Interactions with Sync Gateway's in-memory channel cache.
@@ -765,10 +764,11 @@ properties:
               - `CRUD`: Updates made by Sync Gateway to documents.
               - `DCP`: DCP-feed processing.
               - `Events`: Event processing (webhooks).
-              - `gocb`
+              - `gocb`: Enables Couchbase Go SDK logging.
               - `HTTP`: All requests made to the Sync Gateway REST APIs.
               - `HTTP+`: Additional information about HTTP requests (response times, status codes).
               - `Import`: Introduced in Sync Gateway 1.5 to help troubleshoot the import process of a document (this is the Sync Gateway process to make a document that was added through N1QL or the Server SDKs mobile-aware). This log key can be useful to troubleshoot why a given document was not successfully imported.
+              - `Javascript`: Introduced in Sync Gateway 2.6 and used for sync function and import filter logging.
               - `Migrate`
               - `Query`
               - `Replicate`: Log messages related to replications between Sync Gateways (using sg-replicate). This tag cannot be used for replications initiated by Couchbase Lite.


### PR DESCRIPTION
Update log key reference to match available 2.6.0 log keys:

https://github.com/couchbase/sync_gateway/blob/b4c828d5d167140d75ab4c4f7402602f65f74464/base/log_keys.go#L47-L71