### PR TITLE
DOC-6142 - Deprecate command line option -bucket from Sync Gateway

### DIFF
--- a/modules/ROOT/pages/command-line-options.adoc
+++ b/modules/ROOT/pages/command-line-options.adoc
@@ -23,6 +23,10 @@ You can prefix command-line options with one hyphen (-) or with two hyphens (--)
 Command-line options are case-insensitive.
 Here we use lower camel case.
 
+.*Deprecation Notice*
+
+WARNING: The `-bucket` command line option is deprecated at Release 2.7. It will be removed in Release 2.10. *Instead*, use the JSON configuration file option `bucket` -- see link:config-properties.html#databases-foo_db-bucket[$dbname.bucket]
+
 Following are the command-line options that you can specify when starting Sync Gateway.
 
 [cols="1,1,2"]
@@ -35,7 +39,7 @@ Following are the command-line options that you can specify when starting Sync G
 
 |`-bucket`
 |`sync_gateway`
-|Name of the Couchbase Server bucket.
+|*_Deprecated_* Name of the Couchbase Server bucket.
 
 |`-dbname`
 |`sync_gateway`


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-6142

Deprecate CLI -bucket option at 2.7