### PR TITLE
DOC-6006-Remove-obsolete-configuration-options-for2.0

### DIFF
--- a/modules/ROOT/assets/attachments/sg.yaml
+++ b/modules/ROOT/assets/attachments/sg.yaml
@@ -33,7 +33,7 @@ properties:
         type: array
         description: |
           List of HTTP headers that can be used by domains specified in the `Origin` and `LoginOrigin` properties.
-          
+
           A common value is `["Content-Type"]` as clients use the `Content-Type: application/json` header when sending data as JSON in the body of POST/PUT requests.
         items:
           type: string
@@ -98,9 +98,9 @@ properties:
             type: boolean
             description: |
               If set to `true`, causes the Sync Gateway to scan the bucket on startup looking for documents that have no `_sync` metadata, and adding that metadata. You only want to have this on when you do the first import, because it will slow down the startup of the Sync Gateway. You also only want to run a single Sync Gateway while in this mode, otherwise they'll step on each other's toes trying to generate the `_sync` metadata at the same time.
-              
+
               In Sync Gateway 1.5, the behaviour of this property has changed to work in tandem with the [enable_shared_bucket_access](#1.5/databases-foo_db-enable_shared_bucket_access) property. When **shared bucket access** is enabled, setting this property to continuous (`"import_docs": "continuous"`) indicates that this Sync Gateway node should perform import processing. If **shared bucket access** is not enabled, Sync Gateway continues to support the previously existing import functionality.
-              
+
               In a deployment with **shared bucket access** enabled and [Sync Gateway Accelerator nodes](../accelerator.html), this property is not required because the import process is always shared across Sync Gateway Accelerator.
             default: false
           channel_index:
@@ -148,54 +148,54 @@ properties:
             type: boolean
             description: |
               Starting in Sync Gateway 1.5, Couchbase Server and Mobile applications can now read from and write to the same bucket.
-              
+
               This property specifies whether to enable the interopability between Couchbase Mobile and Couchbase Server. On start-up, Sync Gateway will generate the mobile-specific metadata for all the pre-existing documents in the Couchbase Server bucket. From then on, documents can be inserted on the Server directly (with N1QL or SDKs) or through the Sync Gateway REST API.
-              
+
               Mobile applications require additional metadata in order to manage security and replication. In previous versions of Sync Gateway, this information has always been stored in the document body. Sync Gateway 1.5 utilizes a new feature of Couchbase Server 5.0 called XATTRs (x-attributes) to store that metadata into an external document fragment.
-              
+
               #### Import process
-              
+
               Import is the name for the process by which non-Sync Gateway writes obtain mobile metadata. Any non-Sync Gateway write is eligible for import. A filter function can be specified using the [databases.foo_db.import_filter](#databases-foo_db-import_filter) property to only import specific documents.
-              
+
               The document is first run through the Sync Function to compute read security and routing, with the following specifics/differences:
-              
+
               - The import is processed with an admin user context in the Sync Function, similar to writes made through the Sync Gateway Admin API. This means that `requireAccess`, `requireUser` and `requireRole` calls in the Sync Function are treated as no-ops.
               - During import, `oldDoc` is `nil` when the Sync Function is executed.
-              
+
               Only one node in a Sync Gateway cluster should be configured for feed-based import - it processes the full DCP stream. The [Import+](#log) log key can be used to troubleshoot the import process further in the logs.
-              
+
               ##### Import and Sync Gateway Accelerator
-                  
+
               In a deployment with Sync Gateway Accelerator, feed-based import processing is performed by the Accelerator nodes. Import work is sharded across the Accelerator cluster, in the same way that indexing work is sharded today.
-              
+
               #### Tombstones
-              
+
               When convergence is enabled, mobile tombstones are now also server tombstones. The document body is deleted, and the information required to replicate the tombstone is retained in the mobile extended attribute.
-              
+
               ##### Metadata Purge Interval
-              
+
               The server's metadata purge interval becomes an important consideration for mobile deployments under convergence. When the server purges a tombstone (based on the metadata purge interval), that tombstone will no longer be replicated to mobile clients.
-              
+
               For most mobile deployments, customers should set the server's metadata purge interval based on their expected client replication frequency, to ensure that clients are notified of the tombstone prior to that tombstone being purged.
-              
+
               The default Metadata Purge Interval is set to 3 days which can potentially result in tombstones being purged before all clients have had a chance to get notified of it.
-              
+
               Ways to tune the Metadata Purge Interval on Couchbase Server:
-              
+
               - Bucket settings [on UI](https://developer.couchbase.com/documentation/server/5.0/settings/configure-compact-settings.html)
               - Bucket endpoint [on the REST API](https://developer.couchbase.com/documentation/server/4.6/rest-api/rest-bucket-create.html)
-              
+
               #### Implementation notes for XATTRs:
-              
+
               Extended attributes (xattrs) are JSON objects that can be associated with Couchbase documents. Each document can be associated with zero or more extended attributes. There are currently three types (user, system, virtual). Mobile Convergence uses a system extended attribute, which has the following characteristics central to convergence:
-              
+
                - Shares lifetime with the document metadata - when a document is deleted, system xattrs are preserved with the tombstone.
-               - Allocated 1MB of storage, independent of the 20MB available for the document 
-              
+               - Allocated 1MB of storage, independent of the 20MB available for the document
+
               Extended attributes are stored as part of the document, and are replicated with the document (both intra-cluster replication and XDCR).
-              
+
               Extended attributes can be accessed via the SDKs using the sub-document API, via command-line tools, and via views. They are not yet accessible via N1QL.
-              
+
               Since extended attributes are not yet available via N1QL or the Admin Console, obtaining a document's mobile metadata while troubleshooting is somewhat less straightforward than in 1.4. The [/{db}/_raw/{id}](admin-rest-api.html#/document/get__db___raw__doc_) endpoint on Sync Gateway's Admin REST API returns both the document and it's associated mobile metadata.
             default: 'false'
           event_handlers:
@@ -239,7 +239,7 @@ properties:
             type: string
             description: |
               JavaScript filter function to determine if a document written to the Couchbase Server bucket should be made available to Couchbase Mobile clients (i.e imported). The filter function takes the document body as parameter and is expected to return a boolean to indicate whether the document should be imported.
-              
+
               ```json
               {
                 "databases": {
@@ -336,17 +336,17 @@ properties:
             type: integer
             description: |
               Maximum depth to which a document's revision tree can grow. In Sync Gateway 1.5, the `revs_limit` configuration cannot be set lower than 20. Setting the `revs_limit` to a low value (typically below 100) can have adverse effects as described below.
-              
+
               The value of `revs_limit` governs the point at which to prune a document's revision tree.
-              
+
               Indeed, the process to remove obsolete revisions is called pruning and runs automatically every time a revision is added. Although fundamentally the same, the pruning algorithm works slightly differently between Sync Gateway and Couchbase Lite. On Sync Gateway, the pruning algorithm is applied to the shortest, non-tombstoned branch in the revision tree.
-            
+
               If there are conflicting revisions, the document may end up with **disconnected branches** after the pruning process. In the animation below, the document has a conflicting branch (revisions `4'` - `1001'`). When the shortest branch (in this case the conflicting branch) reaches the 1003rd update, it gets is cut off. The revision tree is not in a corrupted state and the logic that chooses the winning revision still applies. But it may make it impossible to do certain merges (n-way merge) to resolve conflicts and will occupy disk space that could have been free-ed if the conflict was resolved early on.<br><br>
-            
+
               ![](https://cl.ly/3C1G3t3R1v19/pruning-sg.gif)
-              
+
               If the revision tree gets into this state then the only option to resolve the conflict is to pick a winning branch and tombstone all the non-winning conflicting branches. It should be noted that tuning the `revs_limit` to a lower value increases the likelyhood of this scenario happening.
-              
+
               See also:
               - Couchbase Lite [pruning](../../couchbase-lite/native-api/revision/index.html#pruning).
               - Sync Gateway purge endpoint [/{db}/_purge](references/sync-gateway/admin-rest-api/index.html#!/document/post_db_purge).
@@ -369,13 +369,13 @@ properties:
             type: string
             description: |
               In Sync Gateway 1.5, we've added the ability to specify multiple hosts in the configuration. Sync Gateway supports both the `couchbase://` and `http://` schemes for specifying connection endpoints.
-              
+
               Sync Gateway 1.5 also supports SSL in the connection to Couchbase Server. The `couchbases://` scheme should be used. As with the Couchbase Server SDKs, the `https://` scheme is **not** supported.
-            
+
               Hostname(s) to the Couchbase Server nodes in the cluster.
-              
+
               The following are all valid `server` values:
-              
+
                 - `couchbase://host1`
                 - `couchbases://host1`
                 - `couchbase://host1,host2`
@@ -384,20 +384,20 @@ properties:
                 - `http://host1:8091`
                 - `http://host1,host2:8091`
                 - `http://foo:bar@host1:8091`
-                
+
               As with the SDK, when using the `couchbase://` or `couchbases://` schemes, the port is not required, but if specified should be the external/internal bucket ports (defaults are 11210 or 11207 respectively). Attempting to use the admin ports (8091/18091) will result in a startup error.
-              
+
               On startup, Sync Gateway will try each hostname that is provided until it is able to connect successfully.
-              
+
               If the connection to Couchbase Server is lost during normal operations, Sync Gateway will automatically re-connect to another node in the cluster. During that re-connection period, the Sync Gateway will appear [offline](database-offline.html) and documents will not be replicated to mobile clients.
-                
+
               The default value is an in-memory bucket called **walrus** that is only used during development and prototyping.
             default: 'walrus:'
           session_cookie_name:
             type: string
             description: |
               Starting in Sync Gateway 2.0, it is possible to customize the session cookie name that is used for this database. This configuration property is primarly used for web applications interacting with multiple Sync Gateway **databases**. Browsers typically have two methods of determining which cookie to use for a given request: the `URL` path or cookie name. With this property, you can use different cookie names for each database specified in the configuration file. Let's consider the following configuration file:
-              
+
               ```json
               {
                  "interface":":4984",
@@ -422,11 +422,11 @@ properties:
                  }
               }
               ```
-              
+
               With this configuration, the `Set-Cookie` response header of the POST `:4984/{db}/_session` endpoint (Public REST API) would then have the form "CustomName1=3cad4b95524179bf144fe0d92b8f09877bb86bf5;path=/db1/".
-              
+
               When using POST `:4985/{db}/_session` (Admin REST API) to create a session, the cookie value is returned in the response body instead of the `Set-Cookie` header. In this case, it could also be set by the client, for web applications it would be the following in JavaScript:
-              
+
               ```javascript
               cookie1String = "CustomName1=3cad4b95524179bf144fe0d92b8f09877bb86bf5;path=/db1/";
               document.cookie = cookie1String;
@@ -489,7 +489,7 @@ properties:
   log:
     description: |
       Comma-separated list of log keys to enable for diagnostic logging. Use ["*"] to enable logging for all log keys.
-            
+
       - Access: Anytime an access() call is made in the sync function.
       - Attach: Attachment processing.
       - Auth: Authentication.
@@ -524,7 +524,7 @@ properties:
           logKeys:
             description: |
               Comma-separated list of log keys to enable for diagnostic logging. Use ["*"] to enable logging for all log keys.
-              
+
               - Access: Anytime an access() call is made in the sync function.
               - Attach: Attachment processing.
               - Auth: Authentication.
@@ -544,7 +544,7 @@ properties:
           logLevel:
             description: |
               The level of logging.
-              
+
               - debug: 'Print all debug messages. With this level of logging, logs are usually voluminous. This log level is usually disabled in production.'
               - info: 'Print all information messages.'
               - error: 'Print all errors. If an application is running smoothly it should not generate any error level logs.'
@@ -570,14 +570,7 @@ properties:
                 type: boolean
                 description: If true, it uses the computer's local time to format the backup timestamp.
                 default: 'UTC'
-  maxCouchbaseConnections:
-    description: Maximum number of sockets to open to a Couchbase Server node.
-    type: integer
-    default: 16
-  maxCouchbaseOverflow:
-    description: Maximum number of overflow sockets to open.
-    type: integer
-    default: 0
+# Removed MaxCouchbaseConnections and MaxCouchbaseOverflow -- 28Jan2020
   maxFileDescriptors:
     description: Maximum number of open file descriptors.
     type: integer


### PR DESCRIPTION
DOC-6006-Remove-obsolete-configuration-options-for2.0

https://issues.couchbase.com/browse/DOC-6006

Change is at line 573. Other diffs arise from editor stripping trailing whitespace(s) that was left by a previous edit.