### PR TITLE
DOC-6006-Remove-obsolete-configuration-options-for2.1

### DIFF
--- a/modules/ROOT/assets/attachments/sg.yaml
+++ b/modules/ROOT/assets/attachments/sg.yaml
@@ -713,14 +713,7 @@ properties:
                 type: boolean
                 description: If true, it uses the computer's local time to format the backup timestamp. False uses UTC.
                 default: false
-  maxCouchbaseConnections:
-    description: Maximum number of sockets to open to a Couchbase Server node.
-    type: integer
-    default: 16
-  maxCouchbaseOverflow:
-    description: Maximum number of overflow sockets to open.
-    type: integer
-    default: 0
+# Removed MaxCouchbaseConnections and MaxCouchbaseOverflow -- 28Jan2020
   maxFileDescriptors:
     description: Maximum number of open file descriptors.
     type: integer


### PR DESCRIPTION
DOC-6006-Remove-obsolete-configuration-options-for2.1

https://issues.couchbase.com/browse/DOC-6006