### PR TITLE
Update sgcollect_info upload-host for 2.7

### DIFF
--- a/modules/ROOT/pages/sgcollect-info.adoc
+++ b/modules/ROOT/pages/sgcollect-info.adoc
@@ -29,7 +29,7 @@ Collect Sync Gateway diagnostics and save locally:
 ./sgcollect_info /tmp/sgcollect_info.zip
 ----
 
-Collect Sync Gateway diagnostics and upload them to the Couchbase Support AWS S3 bucket:
+Collect Sync Gateway diagnostics and upload them to Couchbase Support:
 
 [source,console]
 ----

--- a/modules/ROOT/pages/sgcollect-info.adoc
+++ b/modules/ROOT/pages/sgcollect-info.adoc
@@ -36,7 +36,7 @@ Collect Sync Gateway diagnostics and upload them to the Couchbase Support AWS S3
 ./sgcollect_info \
   --sync-gateway-config=/path/to/config.json \
   --sync-gateway-executable=/usr/bin/sync_gateway \
-  --upload-host=s3.amazonaws.com/cb-customers \
+  --upload-host=uploads.couchbase.com \
   --customer=Acme \
   --ticket=123
   /tmp/sgcollect_info.zip


### PR DESCRIPTION
Similar to https://github.com/couchbase/docs-sync-gateway/pull/147 but for the sgcollect_info page instead instead of the API reference.