### PR TITLE
DOC-6304-Import-Docs-Continuous

### DIFF
--- a/modules/ROOT/examples/getting-started/sync-gateway-config-import-filter.json
+++ b/modules/ROOT/examples/getting-started/sync-gateway-config-import-filter.json
@@ -7,7 +7,7 @@
       "username": "sync_gateway", // <1>
       "password": "password", // <2>
       "enable_shared_bucket_access": true, // <3>
-      "import_docs": "continuous",
+      "import_docs": true,
       "num_index_replicas": 0, // <4>
       "import_filter": `
         function(doc) { // <5>

--- a/modules/ROOT/examples/getting-started/sync-gateway-config.json
+++ b/modules/ROOT/examples/getting-started/sync-gateway-config.json
@@ -7,7 +7,7 @@
       "username": "sync_gateway", // <1>
       "password": "password", // <2>
       "enable_shared_bucket_access": true, // <3>
-      "import_docs": "continuous",
+      "import_docs": true,
       "num_index_replicas": 0, // <4>
       "users": {
         "GUEST": { "disabled": false, "admin_channels": ["*"] }


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-6304

This legacy setting was deprecated in Release-2.1 This ticket completes the task, removing 'continuous' from the example code-snippet of the config that is included in getting started.master.

It will need applying to Releases 2.1-2.7. The 2.1 release notes will also need amending to reflect the deprecation.