### PR TITLE
DOC-6304-Import-Docs-Continuous

### DIFF
--- a/modules/ROOT/assets/attachments/sg.yaml
+++ b/modules/ROOT/assets/attachments/sg.yaml
@@ -156,6 +156,8 @@ properties:
 
               This configuration is specifically recommended for workload isolation: to isolate import nodes from the client-facing nodes. Workload isolation is preferable in deployments with a large write throughput.
 
+              Prior to Release 2.1 a value of 'continuous' was also allowed. This was deprecated at Release 2.1 and replaced with the boolean value True. There is no change to the behavior or functionality (that is, a value of 'continuous' was interpreted as True and had the same effect).
+
             default: false
           import_partitions:
             type: integer

--- a/modules/ROOT/examples/getting-started/sync-gateway-config-import-filter.json
+++ b/modules/ROOT/examples/getting-started/sync-gateway-config-import-filter.json
@@ -7,7 +7,7 @@
       "username": "sync_gateway", // <1>
       "password": "password", // <2>
       "enable_shared_bucket_access": true, // <3>
-      "import_docs": "continuous",
+      "import_docs": true,
       "num_index_replicas": 0, // <4>
       "import_filter": `
         function(doc) { // <5>

--- a/modules/ROOT/examples/getting-started/sync-gateway-config.json
+++ b/modules/ROOT/examples/getting-started/sync-gateway-config.json
@@ -7,7 +7,7 @@
       "username": "sync_gateway", // <1>
       "password": "password", // <2>
       "enable_shared_bucket_access": true, // <3>
-      "import_docs": "continuous",
+      "import_docs": true,
       "num_index_replicas": 0, // <4>
       "users": {
         "GUEST": { "disabled": false, "admin_channels": ["*"] }


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-6304

This legacy setting was deprecated in release 2.1 and removed, in the main, by DOC-5392. This ticket completes the task, removing form the example code-snippet of the config that is included in getting started.