### PR TITLE
DOC-6304-Import-Docs-Continuous

### DIFF
--- a/modules/ROOT/assets/attachments/sg.yaml
+++ b/modules/ROOT/assets/attachments/sg.yaml
@@ -82,7 +82,11 @@ properties:
 
               `enable_shared_bucket_access` needs to be `true` on all nodes participating in such a configuration where as `import_docs` can only be set to `true` on a single node.
 
+
               **Note:** Prior to Shared Bucket Access being introduced, `import_docs` could be used for one-time imports. This functionality is now superseded by the Shared Bucket Access functionality.
+
+              Prior to Release 2.1 a value of 'continuous' was also allowed. This was deprecated at Release 2.1 and replaced with the boolean value True. There is no change to the behavior or functionality (that is, a value of 'continuous' was interpreted as True and had the same effect).
+
             default: false
           cacertpath:
             type: string

--- a/modules/ROOT/examples/getting-started/sync-gateway-config-import-filter.json
+++ b/modules/ROOT/examples/getting-started/sync-gateway-config-import-filter.json
@@ -7,7 +7,7 @@
       "username": "sync_gateway", // <1>
       "password": "password", // <2>
       "enable_shared_bucket_access": true, // <3>
-      "import_docs": "continuous",
+      "import_docs": true,
       "num_index_replicas": 0, // <4>
       "import_filter": `
         function(doc) { // <5>


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-6304

Backport of PR#182 (Release 2.7)

This legacy setting was deprecated long-ago and removed, in the main, by DOC-5392. This ticket completes the task, removing form the example code-snippet of the config that is included in getting started.master