### PR TITLE
DOC-6198-Backport-revs-limit-changes-to2.0

### DIFF
--- a/modules/ROOT/assets/attachments/sg.yaml
+++ b/modules/ROOT/assets/attachments/sg.yaml
@@ -335,23 +335,46 @@ properties:
           revs_limit:
             type: integer
             description: |
-              Maximum depth to which a document's revision tree can grow. In Sync Gateway 1.5, the `revs_limit` configuration cannot be set lower than 20. Setting the `revs_limit` to a low value (typically below 100) can have adverse effects as described below.
+              This property defines the maximum depth to which a document's revision tree can grow; its value governs the point at which to prune a document's revision tree.
 
-              The value of `revs_limit` governs the point at which to prune a document's revision tree.
+              The default and minimum values of `revs_limit` are dependent on whether [allow_conflicts](config-properties.html#databases-foo_db-allow_conflicts) is set True or False -- see the *Default and Minimum Values* table below.
 
-              Indeed, the process to remove obsolete revisions is called pruning and runs automatically every time a revision is added. Although fundamentally the same, the pruning algorithm works slightly differently between Sync Gateway and Couchbase Lite. On Sync Gateway, the pruning algorithm is applied to the shortest, non-tombstoned branch in the revision tree.
+              The process to remove obsolete revisions is called pruning and runs automatically every time a revision is added. Although fundamentally the same, the pruning algorithm works slightly differently between Sync Gateway and Couchbase Lite. On Sync Gateway, the pruning algorithm is applied to the shortest, non-tombstoned branch in the revision tree.
 
-              If there are conflicting revisions, the document may end up with **disconnected branches** after the pruning process. In the animation below, the document has a conflicting branch (revisions `4'` - `1001'`). When the shortest branch (in this case the conflicting branch) reaches the 1003rd update, it gets is cut off. The revision tree is not in a corrupted state and the logic that chooses the winning revision still applies. But it may make it impossible to do certain merges (n-way merge) to resolve conflicts and will occupy disk space that could have been free-ed if the conflict was resolved early on.<br><br>
+              If there are conflicting revisions, the document may end up with **disconnected branches** after the pruning process. In the animation below, the document has a conflicting branch (revisions `4'` - `1001'`). When the shortest branch (in this case the conflicting branch) reaches the 1003rd update, it gets is cut off. The revision tree is not in a corrupted state and the logic that chooses the winning revision still applies. But it may make it impossible to do certain merges (n-way merge) to resolve conflicts and will occupy disk space that could have been freed if the conflict was resolved early on.<br><br>
 
               ![](https://cl.ly/3C1G3t3R1v19/pruning-sg.gif)
 
-              If the revision tree gets into this state then the only option to resolve the conflict is to pick a winning branch and tombstone all the non-winning conflicting branches. It should be noted that tuning the `revs_limit` to a lower value increases the likelyhood of this scenario happening.
+              If the revision tree gets into this state then the only option to resolve the conflict is to pick a winning branch and tombstone all the non-winning conflicting branches.
+
+              **NOTE:** Setting the `revs_limit` to a value below 100 when `allow_conflicts = true` may adversely affect the conflict resolution process, as there may be insufficient revision history to resolve a given conflict.
+
+              #### Default and Minimum Values
+
+              **For Releases 2.6+**
+
+              allow_conflicts =| True | False
+               :--- | :-------: | :-------:
+              `revs_limit` default | 100 | 50 |
+              `revs_limit` minimum | 20 | 1 |
+
+              **For Releases 2.0 - 2.5**
+
+               allow_conflicts = | <-- True --> |<-- False -->
+               :--- | :-------: | :-------:
+               `revs_limit` default  | 100 | 1000
+               `revs_limit` minimum  | 50 | 1
+
+              **For Release 1.x**
+              - `revs_limit` default = 1000
+              - `revs_limit` minimum = 20
 
               See also:
-              - Couchbase Lite [pruning](../../couchbase-lite/native-api/revision/index.html#pruning).
-              - Sync Gateway purge endpoint [/{db}/_purge](references/sync-gateway/admin-rest-api/index.html#!/document/post_db_purge).
-              - Sync Gateway [document TTLs](references/sync-gateway/admin-rest-api/index.html#!/document/put_db_doc).
-            default: 1000
+              - Sync Gateway purge endpoint [/{db}/_purge](admin-rest-api.html#/document/post__db___purge).
+              - Sync Gateway [document TTLs](admin-rest-api.html#/document/put__db___doc_).
+
+            default: see Default and Minimum Values table in Description
+            minimum: see Default and Minimum Values table in Description
           roles:
             type: object
             description: Initial roles.


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-6198

Staged: https://ibsoln.github.io/stage/DOC-6198-Backport-revs-limit-changes-to2.0/sync-gateway/2.0/config-properties.html#databases-foo_db-revs_limit

Only backport relevant parts of item 3) from this compound change.