### PR TITLE
DOC-5969-point-to-selected-version-backport-to2.6

### DIFF
--- a/modules/ROOT/pages/_partials/_attributesLocal.adoc
+++ b/modules/ROOT/pages/_partials/_attributesLocal.adoc
@@ -1,0 +1,26 @@
+// BEGIN
+
+// SGW Common url links
+:url-jira: https://issues.couchbase.com/browse
+:url-issues-sync: https://github.com/couchbase/sync_gateway/issues
+:url-downloads: https://www.couchbase.com/downloads/?family=mobile
+:url-package-downloads: http://packages.couchbase.com/releases/couchbase-sync-gateway
+
+// SGW Version numbers
+:major: 2
+:minor: 6
+:patch: 1
+:version: {major}.{minor}
+:version-full: {major}.{minor}.0
+:version-maint: {major}.{minor}.{patch}
+
+// SGW Standard text
+:more: Read More
+
+// Editions
+:enterprise: enterprise
+:entshort: ee
+:community: community
+:commshort: ce
+
+// END

--- a/modules/ROOT/pages/authentication.adoc
+++ b/modules/ROOT/pages/authentication.adoc
@@ -1,4 +1,7 @@
 = Authentication
+include::partial$_attributesLocal.adoc[]
+// include::_partials/_mobAttributes.adoc[]
+
 :idprefix:
 :idseparator: -
 :url-openid: https://openid.net/specs/openid-connect-core-1_0.html
@@ -44,10 +47,10 @@ This is the recommended way of using basic authentication.
 
 Example:
 
-* xref:couchbase-lite::swift.adoc#basic-authentication[Swift]
-* xref:couchbase-lite::java.adoc#basic-authentication[Java]
-* xref:couchbase-lite::csharp.adoc#basic-authentication[C#]
-* xref:couchbase-lite::objc.adoc#basic-authentication[Objective-C]
+* xref:{version}@couchbase-lite::swift.adoc#basic-authentication[Swift]
+* xref:{version}@couchbase-lite::java.adoc#basic-authentication[Java]
+* xref:{version}@couchbase-lite::csharp.adoc#basic-authentication[C#]
+* xref:{version}@couchbase-lite::objc.adoc#basic-authentication[Objective-C]
 
 == Auth Providers
 
@@ -106,10 +109,10 @@ It is recommended to return the session details to the client application in the
 
 Example:
 
-* xref:couchbase-lite::swift.adoc#session-authentication[Swift]
-* xref:couchbase-lite::java.adoc#session-authentication[Java]
-* xref:couchbase-lite::csharp.adoc#session-authentication[C#]
-* xref:couchbase-lite::objc.adoc#session-authentication[Objective-C]
+* xref:{version}@couchbase-lite::swift.adoc#session-authentication[Swift]
+* xref:{version}@couchbase-lite::java.adoc#session-authentication[Java]
+* xref:{version}@couchbase-lite::csharp.adoc#session-authentication[C#]
+* xref:{version}@couchbase-lite::objc.adoc#session-authentication[Objective-C]
 
 == OpenID Connect
 

--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -1,5 +1,5 @@
 = Getting Started
-include::_attributes.adoc[]
+include::partial$_attributesLocal.adoc[]
 :idprefix:
 :idseparator: -
 :url-downloads: https://www.couchbase.com/downloads

--- a/modules/ROOT/pages/stats-monitoring.adoc
+++ b/modules/ROOT/pages/stats-monitoring.adoc
@@ -1,5 +1,5 @@
 = Monitoring
-include::_attributes.adoc[]
+include::partial$_attributesLocal.adoc[]
 :xref-cb-config: xref:{version}@sync-gateway:ROOT:stats-monitoring.adoc#
 
 Sync Gateway 2.5 includes a number of new metrics available through the Admin REST API (`/_expvars`).

--- a/modules/ROOT/pages/users-and-roles.adoc
+++ b/modules/ROOT/pages/users-and-roles.adoc
@@ -78,7 +78,7 @@ This method is convenient for testing and to get started, otherwise it is genera
 {
   "databases": {
     "mydatabase": {
-      "users": {
+      "users": { // <1>
         "GUEST": {"disabled": true},
         "john": {"password": "pass", "admin_roles": ["foo"]}
       }


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-5969

Avoid antora's xref to alias issue by using specific versions. Also correct minor issue in:
- user-roles (missing callout number)
- Stats-monitoring (pick-up attributesLocal.adoc from partial$)