### PR TITLE
Update EE download link to latest release

### DIFF
--- a/modules/ROOT/pages/gs-sgw-install.adoc
+++ b/modules/ROOT/pages/gs-sgw-install.adoc
@@ -6,7 +6,7 @@ include::partial$_attributes-local.adoc[]
 
 :sg_download_link: {url-package-downloads}/{version-full}/
 :sg_package_name: couchbase-sync-gateway-community_{version-full}_x86_64
-:sg_package_name_ee: couchbase-sync-gateway-enterprise_{version-full}_x86_64
+:sg_package_name_ee: couchbase-sync-gateway-enterprise_{version-maint}_x86_64
 :sg_accel_package_name: couchbase-sync-gateway-enterprise_{version-full}_x86_64
 
 [abstract]


### PR DESCRIPTION
During our internal server maintenance, I was installing the latest version of SG. I noticed that the default listed download URL was on the latest minor release, not including patch releases.
This PR fixes the URL for the EE.