### PR TITLE
DOC-6269-C5

### DIFF
--- a/modules/ROOT/pages/_partials/block-abstract.adoc
+++ b/modules/ROOT/pages/_partials/block-abstract.adoc
@@ -1,7 +1,11 @@
 // inclusion
+ifeval::["{param-abstract}"=="{empty}"]
+:param-abstract!:
+endif::[]
+
 :this-abstract!:
 ifdef::param-abstract[]
-:this-abstract: {param-abstract}
+:this-abstract: Abstract -- {param-abstract}
 endif::param-abstract[]
 
 // ++++
@@ -13,12 +17,12 @@ endif::param-abstract[]
 ifdef::description[]
 [abstract]
 --
-ifdef::topic-group[]
-Topic Group -- _{topic-group}_ +
-endif::topic-group[]
+// ifdef::topic-group[]
+// Topic Group -- _{topic-group}_ +
+// endif::topic-group[]
 Description -- _{description}_ +
 ifdef::this-abstract[]
-Abstract -- _{this-abstract}_ +
+_{this-abstract}_ +
 endif::this-abstract[]
 // [.column]
 ifdef::param-related[]

--- a/modules/ROOT/pages/_partials/sgw-network-port-reqs.adoc
+++ b/modules/ROOT/pages/_partials/sgw-network-port-reqs.adoc
@@ -5,7 +5,7 @@ Sync Gateway uses specific ports for communication with the outside world, mostl
 
 [#network-ports]
 .Sync Gateway Network Port Requirements
-[cols="1,3"]
+[#network-ports,cols="^1,3"]
 |===
 |Port |Description
 

--- a/modules/ROOT/pages/advance/adv-sgw-cfg-import-filter.adoc
+++ b/modules/ROOT/pages/advance/adv-sgw-cfg-import-filter.adoc
@@ -1,10 +1,20 @@
-= Use Import Filters
+= Import Filters
 :page-type: procedural
-include::partial$_attributes-local.adoc[]
+:page-status:
+:page-edition:
+:page-role:
+:description: Introducing sync functions and how to use them
+:idprefix:
+:idseparator: -
+// End of page attributes
+
+include::partial$_std-hdr-sgw.adoc[]
 :xref-pfx: {xref-pfx-sgw}:
 
-[abstract]
-Provides an example configuration suitable for beginning to use Import Filters
+:param-related: {xref-sgw-pg-config-properties}  |  {xref-sgw-pg-rest-api-admin}
+:param-abstract: Provides an example configuration suitable for beginning to use Import Filters
+include::partial$block-abstract.adoc[]
+
 
 For clusters with a large amount of data, the initial import process can take considerable time to complete.
 Therefore, to get started with a cluster which contains a large number of pre-existing documents, we recommend to use an `import_filter` to reduce the initial import processing time.

--- a/modules/ROOT/pages/advance/adv-sgw-cfg-sync-function.adoc
+++ b/modules/ROOT/pages/advance/adv-sgw-cfg-sync-function.adoc
@@ -1,7 +1,5 @@
-= How do I use Sync Functions?
+= Sync Functions
 :page-type: procedural
-include::partial$_attributes-local.adoc[]
-:page-layout: article
 :page-status:
 :page-edition:
 :page-role:
@@ -10,13 +8,14 @@ include::partial$_attributes-local.adoc[]
 :idseparator: -
 // End of page attributes
 
+include::partial$_std-hdr-sgw.adoc[]
 
 :xref-pfx: {xref-pfx-sgw}:
 
 include::partial$_std-hdr-sgw.adoc[]
 
 :topic-group: {tg-sgw-config}
-:param-related: {xref-sgw-pg-config-properties}  |  {xref-sgw-pg-rest-api-admin} |    {xref-sgw-pg-config-properties-databases}  |  {xref-sgw-pg-config-properties-databases-sync}
+:param-related: {xref-sgw-pg-config-properties}  |  {xref-sgw-pg-rest-api-admin}
 :param-abstract: This content introduces the sync function, provides a simple example configuration suitable for those getting started using sync functions.
 include::partial$block-abstract.adoc[]
 
@@ -38,8 +37,8 @@ Configuration properties:
 <3> The {xref-pfx}shared-bucket-access.adoc[shared bucket access] feature allows Couchbase Server SDKs to also perform operations on this bucket.
 <4> `num_index_replicas` is the number of index replicas stored in Couchbase Server, introduced with {xref-pfx}indexing.adoc[GSI/N1QL indexing].
 If you're running a single Couchbase Server node for development purposes the `num_index_replicas` must be set to `0`.
-<5> The sync function -- a javascript function enclosed in backticks, which is actioned every time a new document, document revision or deletion is made to a data base (see: xref:config-properties.adoc#databases-foo_db-sync[databases.$db.sync] property).
-)
+<5> The sync function -- a javascript function enclosed in backticks, which is actioned every time a new document, document revision or deletion is made to a database -- see: xref:config-properties.adoc#databases-foo_db-sync[databases.$db.sync] property.
+
 
 
 include::partial$block-related-content-sync.adoc[]

--- a/modules/ROOT/pages/advance/deploy/upgrade.adoc
+++ b/modules/ROOT/pages/advance/deploy/upgrade.adoc
@@ -254,7 +254,7 @@ The `replicationId` is used to ensure that any replications previously setup wit
 The restart point will be the last checkpoint used, unless over-ridden.
 
 Over-riding restart point::
-To restart a sync from zero: After the upgrade  reconfigure the Inter-Sync Gateway Replication (v2) {xref-sgw-pg-config-properties-db-replications} to use a different {xref-sgw-pg-config-properties-db-rep-id}
+To restart a sync from zero: After the upgrade reconfigure the Inter-Sync Gateway Replication (v2) {xref-sgw-pg-config-properties-db-replications} to use a different {xref-sgw-pg-config-properties-db-rep-id}
 
 === Constraints
 
@@ -372,7 +372,7 @@ To::
 Strategy::
 * Upgrade sequence
 .. Stop Inter-Sync Gateway Replication (v1) replications
-.. Remove the Inter-Sync Gateway Replication (v1) replication configuration and replace it with Inter-Sync Gateway Replication (v2) equivalent.
+// .. Remove the Inter-Sync Gateway Replication (v1) replication configuration and replace it with Inter-Sync Gateway Replication (v2) equivalent.
 .. Upgrade each cluster to Hydrogen.
 * Restart Outcomes
 ** When The active cluster is restarted it will automatically switch to Inter-Sync Gateway Replication (v2)
@@ -407,7 +407,7 @@ To::
 Strategy::
 * Upgrade sequence
 .. Stop Inter-Sync Gateway Replication (v1) replications
-.. Remove the Inter-Sync Gateway Replication (v1) replication configuration
+// .. Remove the Inter-Sync Gateway Replication (v1) replication configuration
 .. Add the Inter-Sync Gateway Replication (v2) replication configuration, including Javascript function as {xref-sgw-pg-config-properties-db-rep-resolver}
 .. Upgrade each cluster to Hydrogen
 * Restart Outcomes
@@ -419,6 +419,53 @@ Strategy::
 ====
 --
 =====
+
+=== Re-using Pre-2.8 Replication Checkpoints
+You are able to use pre-2.8 replication checkpoints as a starting point for 2.8 replications.
+This can save time on larger buckets by avoiding re-processing documents that have previously been replicated.
+
+To be eligible for re-use use in this way
+
+* These replication parameters MUST match:
+** Replication ID
+** Direction (push or pull only)
+** Previous Source/Target URLs match Remote URL
+** Channel filters
+** DocID filters
+* The new replication must be configured to be unidirectional (there was no bidirectional support prior to 2.8)
+
+=== Upgrade Steps
+
+. Have both pre-2.8 and 2.8 replications defined in the same config file.
+. Ensure prerequisites from previous slide are fulfilled (matching IDs, params, etc.)
+. On startup, SG will determine if replications match, and log:
++
+[source]
+----
+[DBG] Replicate+: Matched replication IDs for SGR1 checkpoint fallback: &{...}
+[INF] Replicate: Got SGR1 checkpoint ID for fallback in replication "repl1-push": b8da8486df3093141f7ed225eb2b2afae88ca9ce
+----
+
+. This prevents the pre-2.8 replication from running, even though it’s configured.
++
+[source]
+----
+[INF] Replicate: Replication "repl1-push" was upgraded, preventing startup of v1 replication.
+[INF] Replicate: Replication "repl1-pull" was upgraded, preventing startup of v1 replication.
+[INF] Replicate: Starting sg-replicate replications...
+----
+. When the 2.8 replication is assigned (even on a different node), the pre-2.8 checkpoint is used if no 2.8 checkpoint can be found. Logs:
++
+[source]
+----
+[DBG] SGCluster+: Replication repl1-pull is assigned to node debbc9ed92243c01 (local node is debbc9ed92243c01)
+[INF] Replicate: Initializing replication repl1-pull
+[INF] Replicate: Attempting to fetch SGR1 checkpoint as fallback: 58782a013091ffc0e7e4ae3c4b6abd8baa7149c6
+[INF] Replicate: c:repl1-pull-pull using checkpointed seq from SGR1: "3"
+----
+. Once the pre-2.8 checkpoint is used, it is deleted to ensure it cannot be used as a fallback again in the event 2.8 checkpoints are removed.
+
+
 :example-caption: {save-title}
 :example-number: {save-num}
 

--- a/modules/ROOT/pages/advance/logging.adoc
+++ b/modules/ROOT/pages/advance/logging.adoc
@@ -7,8 +7,8 @@
 
 include::partial$_std-hdr-sgw.adoc[]
 
-[abstract]
-This page describes the Sync Gateway logging API and how to enable different log settings.
+:param-abstract: This page describes the Sync Gateway logging API and how to enable different log settings.
+include::partial$block-abstract.adoc[]
 
 == Overview
 
@@ -137,3 +137,6 @@ For pre-2.1 log rotation -- see: {xref-sgw-pg-logging-pre2-1}
 
 All log outputs can be redacted, this means that user-data, considered to be private, is removed.
 This feature is optional and can be enabled in the configuration with the xref:config-properties.adoc#logging-redaction_level[`logging.redaction_level`] property.
+
+
+include::partial$block-related-content-api.adoc[]

--- a/modules/ROOT/pages/command-line-options.adoc
+++ b/modules/ROOT/pages/command-line-options.adoc
@@ -1,5 +1,6 @@
 = Command Line Options
 
+== Overview
 To configure Sync Gateway, you can specify command-line options when you start Sync Gateway.
 Command-line options can only specify a limited set of configuration properties, and cannot be used to configure multiple databases.
 For more comprehensive configuration, use a JSON configuration file.
@@ -10,6 +11,7 @@ Configuration determines the runtime behavior of Sync Gateway, including server 
 NOTE: You can only specify a small subset of configuration properties as command-line options.
 Two command-line options do not have corresponding configuration properties: `-help` and `-verbose`.
 
+
 When specifying command-line options, the format of the `sync_gateway` command is:
 
 [source,bash]
@@ -17,7 +19,7 @@ When specifying command-line options, the format of the `sync_gateway` command i
 sync_gateway [command-line options]
 ----
 
-== Command-line options
+== Command-line Options
 
 You can prefix command-line options with one hyphen (-) or with two hyphens (--). For command-line options that take an argument, you specify the argument after an equal sign (=), for example, `-bucket=db`, or as a following item on the command line, for example, `-bucket db`.
 Command-line options are case-insensitive.
@@ -122,3 +124,5 @@ The following command accomplishes the same things as the prior command, persist
 ----
 $ sync_gateway -url=walrus:///tmp/walrus -bucket=db -log=HTTP+,CRUD
 ----
+
+include::partial$block-related-content-api.adoc[]

--- a/modules/ROOT/pages/database-offline.adoc
+++ b/modules/ROOT/pages/database-offline.adoc
@@ -1,11 +1,18 @@
 = Taking Databases Offline and Online
+:page-layout: article
+:page-role:
+:page-status:
+:page-content: conceptual
 
-Sync Gateway 1.2 introduces functionality that permits a specific database to be taken offline and brought back online, without requiring that the Sync Gateway instance be stopped and without affecting other databases that are served by the instance.
+include::partial$_std-hdr-sgw.adoc[]
+
+== Overview
+Sync Gateway enables a database to be taken offline and brought back online, without requiring that the Sync Gateway instance be stopped and without affecting other databases that are served by the instance.
 
 This online/offline status for a database is with respect to a specific Sync Gateway instance.
 The status does not apply to other Sync Gateway instances, unless coordinated operations there have brought the databases on those instances into the same state.
 
-== Motivation and use cases
+== Motivation and Use Cases
 
 Specific uses for the database offline/online functionality include:
 
@@ -26,13 +33,13 @@ To keep a database offline when Sync Gateway starts, you can add the `offline` c
 
 Later, to bring the database online, you can use the `+POST /{tkn-db}/_online+` Admin REST API request.
 
-=== Offline state triggers
+=== Offline State Triggers
 
 Sync Gateway will take a database offline automatically if specific conditions occur.
 Specifically, if Sync Gateway detects that the DCP feed or TAP feed for a database has been lost, then Sync Gateway takes the database offline automatically, so that the problem can be investigated.
 When the cause is known and has been corrected, you can use an Admin REST API request to bring the database back online.
 
-=== State diagram
+=== State Diagram
 
 This state diagram represents the states for Sync Gateway and for the connection between Sync Gateway and a Couchbase Server database.
 
@@ -43,3 +50,5 @@ In the state diagram:
 * To the left of the gray dashed line, starting or stopping a Sync Gateway instance affects the connections to all of the databases that the instance serves.
 * To the right of the gray dashed line, you perform operations on specific databases.
 For example, two databases could be online, while a third database could be taken offline, resynchronized, and then brought back online.
+
+include::partial$block-related-content-api.adoc[]

--- a/modules/ROOT/pages/learn/concept-tombstones.adoc
+++ b/modules/ROOT/pages/learn/concept-tombstones.adoc
@@ -6,8 +6,6 @@
 
 include::partial$_std-hdr-sgw.adoc[]
 
-xref:glossary.adoc[Mobile tombstones] enable mobile clients to be notified when a document has been deleted.
-
 == What tombstones are
 
 A _tombstone_ is a persistent record that an item has been deleted.
@@ -29,12 +27,6 @@ The actual tombstone artefact is a document revision comprising only:
   "_rev": "3-db962c6d93c3f1720cc7d3b6e50ac9df"
 }
 ----
-
-== How sync gateway uses tombstones
-
-
-
-
 
 == The tombstone lifecycle
 

--- a/modules/ROOT/pages/learn/concept-tombstones.adoc
+++ b/modules/ROOT/pages/learn/concept-tombstones.adoc
@@ -1,7 +1,11 @@
 = Tombstones
-include::partial$_attributes-local.adoc[]
+:page-layout: article
+:page-role:
+:page-status:
+:page-content: conceptual
 
-[abstract]
+include::partial$_std-hdr-sgw.adoc[]
+
 xref:glossary.adoc[Mobile tombstones] enable mobile clients to be notified when a document has been deleted.
 
 == What tombstones are
@@ -92,3 +96,5 @@ Whether your synchronizations are purely sync gateway or you use Couchbase Lite,
 * xref:shared-bucket-access.adoc#metadata-purge-interval[Metadata Purge Interval]
 * xref:config-properties.adoc#databases-foo_db-enable_shared_bucket_access[$dbname.enable_shared_bucket_access]
 * xref:server:learn:buckets-memory-and-storage/storage.adoc#tombstones[Server Tombstones]
+
+include::partial$block-related-content-api.adoc[]

--- a/modules/ROOT/pages/load-balancer.adoc
+++ b/modules/ROOT/pages/load-balancer.adoc
@@ -3,7 +3,7 @@
 This guide covers various aspects to consider when using a Load Balancer in a Couchbase Mobile deployment.
 In particular, when using NGINX or AWS Elastic Load Balancer (ELB).
 
-== When to use a reverse proxy
+== When to Use a Reverse Proxy
 
 * A reverse proxy can hide the existence of a Sync Gateway server or servers.
 This can help to secure the Sync gateway instances when your service is exposed to the internet.
@@ -46,7 +46,7 @@ http://127.0.0.1/
 
 Note: Replace 127.0.0.1 with the IP address of your server.
 
-=== Basic nginx configuration for Sync Gateway
+=== Basic NGINX Configuration
 
 If you installed nginx using the instructions above, then you will create your sync_gateway configuration file in */etc/nginx/sites-available*.
 Create a file in that directory called sync_gateway with the following content:
@@ -149,7 +149,7 @@ Note: Replace 127.0.0.1 with the IP address of your server.
 
 You should see the standard Welcome to nginx! page.
 
-=== Load-balancing requests across multiple Sync Gateway instances
+=== Load-balancing Multiple Sync Gateway Instances
 
 Sync Gateway instances have a "shared nothing" architecture: this means that you can scale out by simply deploying additional Sync Gateway instances.
 But incoming traffic needs to be distributed across all the instances.
@@ -242,3 +242,5 @@ This tells curl to accept an untrusted certificate; without this, the command wi
 Since Sync Gateway and Couchbase Lite can have long running connections for changes feeds, you should set the *Idle Timeout* setting of the ELB to the maximum value of 3600 seconds (1 hour).
 
 See the https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/config-idle-timeout.html[ELB instructions] for more information on how to change this setting.
+
+include::partial$block-related-content-api.adoc[]

--- a/modules/ROOT/pages/managing-tombstones.adoc
+++ b/modules/ROOT/pages/managing-tombstones.adoc
@@ -1,4 +1,10 @@
 = Managing Tombstones
+:page-layout: article
+:page-role:
+:page-status:
+:page-content: conceptual
+
+include::partial$_std-hdr-sgw.adoc[]
 
 xref:glossary.adoc[Mobile tombstones] enable mobile clients to be notified when a document has been deleted.
 
@@ -99,3 +105,7 @@ Document operations also have a different impact on tombstones when Shared Bucke
 |N/A
 |Removes the tombstone metadata
 |===
+
+
+include::partial$block-related-content-api.adoc[]
+

--- a/modules/ROOT/pages/os-level-tuning.adoc
+++ b/modules/ROOT/pages/os-level-tuning.adoc
@@ -3,7 +3,7 @@
 
 To get the most out of Sync Gateway, it may be necessary to tune a few parameters of the OS.
 
-== Tuning the max no. of file descriptors
+== File Descriptors
 
 Raising the maximum number of file descriptors available to Sync Gateway is important because it directly affects the maximum number of *sockets* the Sync Gateway can have open, and therefore the maximum number of endpoints that the Sync Gateway can support.
 
@@ -11,7 +11,7 @@ Raising the maximum number of file descriptors available to Sync Gateway is impo
 
 The following instructions are geared towards CentOS.
 
-==== Global limits
+==== Global Limits
 
 Increase the max number of file descriptors available to *all processes*.
 To specify the number of system wide file descriptors allowed, open up the `/etc/sysctl.conf` file and add the following line.
@@ -85,11 +85,11 @@ The value of both commands above should be `250000`.
 * https://glassonionblog.wordpress.com/2013/01/27/increase-ulimit-and-file-descriptors-limit/[Increasing ulimit and file descriptors limit on Linux]
 
 
-== Tuning the TCP Keepalive parameters
+== TCP Keepalive Parameters
 
 If you have already raised the maximum number of file descriptors available to Sync Gateway, but you are still seeing "too many open files" errors, you may need to tune the TCP Keepalive parameters.
 
-=== Understanding the problem
+=== Understanding the Problem
 
 Mobile endpoints tend to abruptly disconnect from the network without closing their side of the connection, as described in {url-keepalive}/overview.html[Section 2.3. (Checking for dead peers)] of the TCP-Keepalive-HOWTO.
 
@@ -150,3 +150,5 @@ See {url-keepalive}/usingkeepalive.html[Using TCP keepalive under Linux] for mor
 * https://groups.google.com/forum/#!msg/golang-nuts/rRu6ibLNdeI/0bjSmO5fN_8J[Proactively closing longpoll connections for endpoints that disappear from the network]
 * https://linux.die.net/man/7/tcp[TCP man page]
 * https://github.com/couchbase/sync_gateway/issues/742[Sync Gateway Issue 742]
+
+include::partial$block-related-content-api.adoc[]

--- a/modules/ROOT/pages/refer/refer-sgw-glossary.adoc
+++ b/modules/ROOT/pages/refer/refer-sgw-glossary.adoc
@@ -131,7 +131,6 @@ See: <<custom-conflict-resolver>>
 
 --
 // end::conflict-resolver-policies-body[]
---
 // end::conflict-resolver-policies-full[]
 
 

--- a/modules/ROOT/pages/security.adoc
+++ b/modules/ROOT/pages/security.adoc
@@ -42,19 +42,19 @@ A path to a PEM-format file containing the certificate's matching private key.
 If both properties are present, the server will respond to SSL (and only SSL) over both the public and admin ports.
 If you want to support both HTTP and HTTPS connections you will need to run two separate instances of Sync Gateway.
 
-=== How to create an SSL certificate
+=== How to Create an SSL Certificate
 
 Certificates are a complex topic.
 There are basically two routes you can go: request a certificate from a Certificate Authority (CA), or create your own "self-signed" certificate.
 
-==== Requesting a certificate from a CA
+==== Requesting a Certificate from a CA
 
 You can obtain a certificate from a trusted https://en.wikipedia.org/wiki/Certificate_authority[Certificate Authority] (CA). Examples of trusted CAs include https://letsencrypt.org/[Let's Encrypt], Thawte or GoDaddy.
 What this means is that their own root certificates are known and trusted by operating systems, so any certificate that they sign will also be trusted.
 
 Hence, the benefit of a certificate obtained from a trusted CA is that it will be trusted by any SSL client.
 
-==== Creating your own self-signed certificate
+==== Creating a Self-Signed Certificate
 
 Unlike a CA-signed cert, a self-signed cert isn't intrinsically trustworthy: a client can't tell who you are by examining the cert, because no recognized authority has vouched for it.
 But a self-signed cert is still unique (only you, as the holder of the private key, can operate a server using that cert), and it still allows the connection to be encrypted.
@@ -81,7 +81,7 @@ To create a copy of the cert in binary DER format (often stored in a ".cer" file
 $ openssl x509 -inform PEM -in cert.pem -outform DER -out cert.cer
 ----
 
-=== Installing the certificate
+=== Installing the Certificate
 
 Whichever way you obtained the certificate, you will now have a private key and an X.509 certificate.
 Ensure that they're in separate files and in PEM format, and put them in a directory that's readable by the Sync Gateway process.
@@ -164,3 +164,5 @@ More detail on the configuration properties for x.509 authentication can be foun
 * xref:config-properties.adoc#databases-foo_db-cacertpath[databases.$db.cacertpath]
 
 If the **username**/**password** properties are also specified in the configuration file then Sync Gateway will use password-based authentication and also include the client certificate in the TLS handshake.
+
+include::partial$block-related-content-api.adoc[]

--- a/modules/ROOT/pages/sgcollect-info.adoc
+++ b/modules/ROOT/pages/sgcollect-info.adoc
@@ -1,5 +1,11 @@
 = SG Collect Info
 
+include::partial$_std-hdr-sgw.adoc[]
+
+:param-abstract: This page describes the command line statistics utility, `sgcollect`
+include::partial$block-abstract.adoc[]
+
+== Overview
 `sgcollect_info` is command line utility that provides detailed statistics for a specific Sync Gateway node.
 This tool must be run on each node individually, not on all simultaneously.
 
@@ -11,7 +17,7 @@ This tool must be run on each node individually, not on all simultaneously.
 . System Level OS stats
 . Golang profile output (runtime memory and cpu profiling info)
 
-== CLI command and parameters
+== CLI Command and Parameters
 
 To see the CLI command line parameters, run:
 
@@ -46,7 +52,7 @@ Collect Sync Gateway diagnostics and upload them to Couchbase Support:
 
 `sgcollect_info` can now be run from the Admin REST API as of Sync Gateway 2.1 using the xref:admin-rest-api.adoc#/server/post__sgcollect_info[_sgcollect_info] endpoint.
 
-== Zipfile contents
+== Zipfile Contents
 
 The tool creates the following log files in the ouput file.
 
@@ -115,7 +121,7 @@ The tool creates the following log files in the ouput file.
 |The pprof output that collects directly via an http client rather than using go tool, in case Go is not installed
 |===
 
-=== File concatenation
+=== File Concatenation
 
 SGCollect Info has been updated to use the xref:logging.adoc#continuous-logging[continuous logging] feature introduced in 2.1, and collects the four leveled files (*sg_error.log*, *sg_warn.log*, *sg_info.log* and *sg_debug.log*).
 
@@ -143,3 +149,5 @@ Zipfile built: sgout.zip
 ----
 
 * `--log-redaction-salt=SALT_VALUE`: salt used in the hashing of tagged data when enabling redaction. Defaults to a random uuid.
+
+include::partial$block-related-content-api.adoc[]

--- a/modules/ROOT/pages/sgw-whatsnew.adoc
+++ b/modules/ROOT/pages/sgw-whatsnew.adoc
@@ -24,7 +24,7 @@ include::partial$pn-change-log-content.adoc[tag=2-8-0-inter-sync-gateway, levelo
 // === Metrics API - developer preview
 include::partial$pn-change-log-content.adoc[tag=2-8-0-metrics, leveloffset=+1]
 
-=== Fixes and enhancements
+=== Fixes and Enhancements
 
 This release also contains a number of bug fixes and enhancements for Sync Gateway.
 

--- a/modules/ROOT/pages/shared-bucket-access.adoc
+++ b/modules/ROOT/pages/shared-bucket-access.adoc
@@ -3,14 +3,12 @@
 :page-role:
 :page-status:
 :page-content: conceptual
-include::partial$_attributes-local.adoc[]
-:pageOriginRel: "sg=1.5, Cbs=5.0)_"
 :description: Sync Gateway replication keeps distributed database changes in sync
 :keywords: sync gateway, replication, sync, synchronization, edge, cloud
-
+:pageOriginRel: "sg=1.5, Cbs=5.0)_"
 
 include::partial$_std-hdr-sgw.adoc[]
-include::partial$block-authors-notes.adoc[tag=wip]
+
 :topic-group: Replication
 :param-related: {xref-sgw-pg-config-properties} | {xref-sgw-pg-rest-api-admin}
 :param-abstract: This content describes how Sync Gateway synchronizes document changes made through Couchbase SDKs and N1QL queries.
@@ -27,7 +25,7 @@ In previous releases, you either had to ensure all writes happened through Sync 
 As of Sync Gateway 1.5, the metadata created by the Sync Gateway is abstracted from applications reading and writing data directly to Couchbase Server.
 Sync Gateway 1.5 utilizes a new feature of Couchbase Server 5.0 called XATTRs (e**X**tended **ATTR**ibutes) to store that metadata into an external document fragment.
 
-== How to enable it
+== Enable Shared Bucket Access
 
 Shared bucket access is an opt-in feature, and can be enabled without bringing down the entire Sync Gateway cluster.
 
@@ -59,7 +57,7 @@ The xref:getting-started.adoc[getting started] page includes step-by-step instru
 Once enabled, documents can be inserted on the Server directly (using _N1QL_ or _SDKs_) or through the xref:rest-api.adoc[Sync Gateway REST API].
 The mobile metadata is no longer kept in the document, but in a system extended attribute in Couchbase Server.
 
-== Import process
+== Import Process
 
 The import process is a key part of mobile convergence.
 
@@ -123,7 +121,7 @@ The following table describes the key behavior differences between Community Edi
 | Import docs is false
 |===
 
-== High Availability of Import processing
+== High Availability of Import Processing
 
 In _Enterprise Edition_, import processing work is sharded across all Sync Gateway nodes with import enabled.
 This implies that if one of the nodes fail, the failed shard is automatically picked up by the remaining nodes in the cluster.

--- a/modules/ROOT/pages/start/gs-sgw-config.adoc
+++ b/modules/ROOT/pages/start/gs-sgw-config.adoc
@@ -1,10 +1,11 @@
 = Configure Sync Gateway
 :page-type: procedural
-include::partial$_attributes-local.adoc[]
+
+include::partial$_std-hdr-sgw.adoc[]
 :xref-pfx: {xref-pfx-sgw}:
 
-[abstract]
-Provides an example configuration suitable for the Getting Started activity
+:param-abstract: Provides an example configuration suitable for the Getting Started activity
+include::partial$block-abstract.adoc[]
 
 The following steps explain how to configure Sync Gateway to connect to a Couchbase Server instance.
 
@@ -16,7 +17,7 @@ The following steps explain how to configure Sync Gateway to connect to a Couchb
 include::{example-cfg}[tag="getting-started-config"]
 ----
 
-.Configuration properties:
+.Configuration Properties:
 
 <1> The user's username that you created on the Couchbase Server Admin Console.
 <2> The user's password that you created on the Couchbase Server Admin Console.
@@ -44,15 +45,6 @@ The sequence number increments for every change that happens on the Sync Gateway
 ** Query a document by ID on the Sync Gateway REST API ({xref-pfx}rest-api.adoc#/document/get\__db___doc_[`+GET /{tkn-db}/{id}+`]).
 ** Query a document from the Query Workbench on the Couchbase Server Console.
 
-== Related Information
 
-.Next Steps:
-* {xref-pfx}gs-sgw-api-access.adoc[Access the APIs]
+include::partial$block-related-content-deploy.adoc[]
 
-.Learn more:
-* {xref-pfx}admin-rest-api.adoc[About the Admin API]
-* {xref-pfx}rest-api.adoc[About the Public API]
-* {xref-pfx}config-properties.adoc[Config Schema Reference]
-
-.Do more:
-** _Rest API Client_: {xref-pfx}rest-api-client.adoc[Build a simple api client]

--- a/modules/ROOT/pages/start/gs-sgw-install.adoc
+++ b/modules/ROOT/pages/start/gs-sgw-install.adoc
@@ -1,7 +1,8 @@
 = Installing Sync Gateway
 :page-aliases: getting-started
 :page-type: procedural
-include::partial$_attributes-local.adoc[]
+
+include::partial$_std-hdr-sgw.adoc[]
 :xref-pfx: {xref-pfx-sgw}:
 
 :sg_download_link: {url-package-downloads}/{version-full}/
@@ -9,8 +10,8 @@ include::partial$_attributes-local.adoc[]
 :sg_package_name_ee: couchbase-sync-gateway-enterprise_{version-full}_x86_64
 :sg_accel_package_name: couchbase-sync-gateway-enterprise_{version-full}_x86_64
 
-[abstract]
-This content explains how to install a Sync Gateway instance
+:param-abstract: This content explains how to install a Sync Gateway instance
+include::partial$block-abstract.adoc[]
 
 .Preparatory Steps
 NOTE: Before starting ensure you have read and actioned the steps in {xref-pfx}gs-sgw-prereqs.adoc[Before You Start]
@@ -421,16 +422,6 @@ The configuration file and logs are located in `/Users/sync_gateway`.
 --
 ====
 
-== Related Information
 
-.Next Steps
-* {xref-pfx}gs-sgw-config.adoc[Configure Sync Gateway]
+include::partial$block-related-content-deploy.adoc[]
 
-.Learn more:
-* {xref-pfx}shared-bucket-access.adoc[About data synchronization]
-* {xref-pfx}sync-function.adoc[About Sync Functions]
-* {xref-pfx}config-properties.adoc[Config Schema Reference]
-
-.Do more:
-** _Import Filters_: To use Sync Gateway on clusters with a large amount of data you can configure an _import filter_ (see: {xref-pfx}ad-sgw-cfg-import-filter.adoc[Configure import filter]).
-** _Sync Functions_: For finer gained control of document access, you can  {xref-pfx}ad-sgw-cfg-sync-function.adoc[Configure Sync Function].

--- a/modules/ROOT/pages/start/gs-sgw-prereqs.adoc
+++ b/modules/ROOT/pages/start/gs-sgw-prereqs.adoc
@@ -1,5 +1,7 @@
 = Sync Gateway Prerequsities
-include::partial$_attributes-local.adoc[]
+
+include::partial$_std-hdr-sgw.adoc[]
+
 :xref-pfx: {xref-pfx-sgw}:
 
 :sg_download_link: {url-package-downloads}/{version-full}/
@@ -8,9 +10,12 @@ include::partial$_attributes-local.adoc[]
 :sg_accel_package_name: couchbase-sync-gateway-enterprise_{version-full}_x86_64
 :btn-pfx: Select btn:
 
+:param-abstract!:
+include::partial$block-abstract.adoc[]
+
 == Couchbase Server
 Before you can usefully use Sync Gateway, you must have an operational Couchbase Server installation.
-You will need to add a Bucket and an RBAC User for Sync Gateway (see: {xref-pfx}gs-sgw-svr-cfg.adoc[Configure Server for Sync Gateway]).
+You will need to add a Bucket and an RBAC User for Sync Gateway -- see: {xref-sgw-pg-gs-sgw-svr-cfg}.
 
 See also: <<sgw-and-couchbase-server>>
 
@@ -30,8 +35,9 @@ include::partial$sgw-svr-ports.adoc[]
 
 == Compatibility
 
-<<sgw-and-couchbase-server,Server>> | <<sgw-and-couchbase-lite,Couchbase Lite>> | <<supported-operating-systems,OS>> |<<coud-support,Cloud>> |
+<<sgw-and-couchbase-server,Server>> | <<sgw-and-couchbase-lite,Couchbase Lite>> | <<supported-operating-systems,OS>> |<<cloud-support,Cloud>> |
 
+[#sgw-and-couchbase-server]
 === Sync Gateway and Couchbase Server
 include::partial$sgw-svr-compatibility.adoc[]
 
@@ -44,16 +50,10 @@ include::partial$sgw-supported-os.adoc[tags=sup-os-dev-test-prod]
 
 include::partial$sgw-supported-os.adoc[tags=sup-os-dev-test]
 
+[#cloud-support]
 === Cloud Support
 include::partial$sgw-supported-os.adoc[tags=sup-os-cloud]
 
 
-== Related Information
+include::partial$block-related-content-deploy.adoc[]
 
-.Next Steps
-* {xref-pfx}gs-sgw-svr-cfg.adoc[Configure Server for Sync Gateway]
-
-.Learn more:
-* {xref-pfx}shared-bucket-access.adoc[About data synchronization]
-* {xref-pfx}sync-function.adoc[About Sync Functions]
-* {xref-pfx}config-properties.adoc[Config Schema Reference]

--- a/modules/ROOT/pages/start/gs-sgw-svr-cfg.adoc
+++ b/modules/ROOT/pages/start/gs-sgw-svr-cfg.adoc
@@ -11,7 +11,7 @@ include::partial$_attributes-local.adoc[]
 
 Assuming you have an operational Couchbase Server deployment then:
 
-== STEP 1 -- Create a bucket
+== STEP 1 -- Create a Bucket
 
 We will use this bucket to test the deployment of Sync Gateway, later in the Getting Started section.
 
@@ -29,7 +29,7 @@ You can leave the other options to their defaults.
 +
 image::cb-create-bucket-popup.png[]
 
-== STEP 2 -- Create RBAC user
+== STEP 2 -- Create RBAC User
 
 // tag::create-rbac-user[]
 
@@ -68,7 +68,7 @@ image::user-settings.png[]
 
 // end::create-rbac-user[]
 
-== STEP 3 -- Set-up Network access
+== STEP 3 -- Set-up Network Access
 
 When installing Couchbase Server on the cloud, ensure that network permissions (or firewall settings) allow incoming connections to Couchbase Server ports.
 
@@ -79,15 +79,6 @@ If this is not done, the Couchbase Server node can experience difficulty joining
 You can refer to the {xref-pfx-svr}install:install-ports.adoc
 [Couchbase Server Network Configuration] guide to see the full list of available ports and their associated services.
 
-== Related Information
 
-.Next Steps
-* {xref-pfx}gs-sgw-install.adoc[Install Sync Gateway]
+include::partial$block-related-content-deploy.adoc[]
 
-.Learn more:
-* {xref-pfx}shared-bucket-access.adoc[About data synchronization]
-* {xref-pfx}config-properties.adoc[Config Schema Reference]
-
-.Do more:
-** _Import Filters_: To use Sync Gateway on clusters with a large amount of data you can configure an _import filter_ (see: {xref-pfx}ad-sgw-cfg-import-filter.adoc[Configure import filter]).
-** _Sync Functions_: For finer gained control of document access, you can  {xref-pfx}ad-sgw-cfg-sync-function.adoc[Configure Sync Function].


### PR DESCRIPTION
- supres topic-group and empty abstracts
- remove properties from sync-function's releated content header
- Correct glossary heading
- Correct heading case in Whats New page
- Correct link to anchor sgw-and-couchbase-server and cloud-support in pre-reqs
- Correct heading case and related content blocks
-Correct heading case in shared-bucket
- Retitle Sync Function
- Correct heading case in import, sync, database state and rest api cllient
- Apply Adam's feedback on upgrades