### PR TITLE
DOC-7767 - Correct overwritten text on gs-sgw-api-access page

### DIFF
--- a/modules/ROOT/pages/start/gs-sgw-api-access.adoc
+++ b/modules/ROOT/pages/start/gs-sgw-api-access.adoc
@@ -2,7 +2,7 @@
 :page-layout: article
 :page-status:
 :page-edition:
-:page-role: -toc
+:page-role:
 :page-content: Reference
 :description: Sync Gateway REST API Access
 


### PR DESCRIPTION
Remove -toc entry from page-role to avoid UI error resulting in over writing of text prior to table caption.
https://issues.couchbase.com/browse/DOC-7767