### PR TITLE
DOC-8036-C2 Forward-porting DOC-8036 from 2.7

### DIFF
--- a/modules/ROOT/assets/attachments/sg.yaml
+++ b/modules/ROOT/assets/attachments/sg.yaml
@@ -335,9 +335,9 @@ properties:
             description: |+
               Introduced in Sync Gateway 1.5, this property specifies whether to enable Mobile-Server Data Sync (a.k.a _mobile convergence_). You can learn more about this functionality in [Syncing Mobile and Server](./../shared-bucket-access.html)
 
-              This property works in conjunction with the [import_docs](#databases-this_db-import_docs) property.
+              This property works in conjunction with the [import_docs](#databases-foo_db-import_docs) property, which determines whether a node participates in import processing.
 
-              `enable_shared_bucket_access` needs to be `true` on all nodes participating in such a configuration where as `import_docs` can only be set to `true` on a single node.
+              Set `enable_shared_bucket_access` to `true` on all nodes participating in such a configuration.
 
               On start-up, Sync Gateway will generate the mobile-specific metadata for all the pre-existing documents in the Couchbase Server bucket. From then on, documents can be inserted on the Server directly (with N1QL or SDKs) or through the Sync Gateway REST API.
 


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-8036
Sync Gateway 2.7+ enable_shared_bucket_access references old import_docs behavior

(cherry picked from commit 9ecee2b68c4297fc3571a597d57dfad08bc17f1f)