### PR TITLE
DOC-7189 -- Remove reference to redundant swagger spec changelog

### DIFF
--- a/modules/ROOT/pages/advance/adv-rest-api-client.adoc
+++ b/modules/ROOT/pages/advance/adv-rest-api-client.adoc
@@ -107,10 +107,11 @@ window.client = new SwaggerClient({
 Here you're initializing the Swagger library with the Sync Gateway public REST API spec and promises enabled.
 Promises are great because you can chain HTTP operations in a readable style.
 
-NOTE: Keep in mind that in this example the Swagger client is pointing to the spec hosted on developer.couchbase.com.
-We often publish changes to those specs for documentation purposes; if it's a breaking change then it will modify the request and parameter names in the Swagger client and break your code.
-You can refer to the https://github.com/couchbaselabs/couchbase-mobile-portal/blob/master/swagger/CHANGELOG.md[changelog of the specs] to find the list of methods and parameters that changed.
-In production, we highly encourage you to download the spec as a `$$.$$json` file and pass it to the Swagger client using the `{spec: <spec>}` option.
+// No longer relevant; updates are made in this spec
+// NOTE: Keep in mind that in this example the Swagger client is pointing to the spec hosted on developer.couchbase.com.
+// We often publish changes to those specs for documentation purposes; if it's a breaking change then it will modify the request and parameter names in the Swagger client and break your code.
+// You can refer to the https://github.com/couchbaselabs/couchbase-mobile-portal/blob/master/swagger/CHANGELOG.md[changelog of the specs] to find the list of methods and parameters that changed.
+// In production, we highly encourage you to download the spec as a `$$.$$json` file and pass it to the Swagger client using the `{spec: <spec>}` option.
 
 In this working directory, start a web server with the command `python -m SimpleHTTPServer 8000` and navigate to \http://localhost:8000/index.html in a browser.
 Open the dev tools to access the console and you should see the list of operations available on the `client` object.


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-7189

(cherry picked from commit 7f7a4a0a1cf2e855e9fa47681da1ac3b65f14032)