### PR TITLE
DOC_7751 -- Replace deprecated property "log" with "logging"

### DIFF
--- a/modules/ROOT/examples/configuration/sync-gateway-config.json
+++ b/modules/ROOT/examples/configuration/sync-gateway-config.json
@@ -2,7 +2,6 @@
 //
 {
   //  ... additional configuration data as required ...
-  "log": ["*"],
   "databases": {
     "getting-started-db": {
       "server": "http://localhost:8091",
@@ -14,6 +13,11 @@
       "num_index_replicas": 0, // <4>
       "users": {
         "GUEST": { "disabled": false, "admin_channels": ["*"] }
+      }
+    }
+    "logging": {
+      "console":  {
+        "log-keys": ["*"]
       }
     }
     //  ... additional configuration data as required ...


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-7751

Deprecated property "log" mentioned in the sample Sync Gateway 2.8 configuration JSON file