### PR TITLE
DOC-8078 -- Alternate connection overrides

### DIFF
--- a/modules/ROOT/assets/attachments/sg.yaml
+++ b/modules/ROOT/assets/attachments/sg.yaml
@@ -613,7 +613,7 @@ properties:
                   admin_channels:
                     type: array
                     description: |
-                      The list of channels this role is automatically granted access to when Sync Gateway starts.  
+                      The list of channels this role is automatically granted access to when Sync Gateway starts.
                       If "*" is specified then the role is granted access to the star channel which contains all documents.
                     items:
                       type: string
@@ -649,7 +649,24 @@ properties:
 
               As with the SDK, when using the `couchbase://` or `couchbases://` schemes, the port is not required, but if specified should be the external/internal bucket ports (defaults are 11210 or 11207 respectively). Attempting to use the admin ports (8091/18091) will result in a startup error.
 
+              *Alternate Addresses*
+
               On startup, Sync Gateway will try each hostname that is provided until it is able to connect successfully.
+
+              By default, if a remote cluster has an external address set, then when SG connects it will always use the external address.
+              However, it is possible to override this behavior by adding a `network` parameter to the connection string.
+
+              The `network` parameter can be --
+              - auto -- this is the default value if no parameter is provided; there is no override
+              - external -- to always force use of the external address
+              - default -- to always force use of the internal address
+
+              For example:
+              ```"server": "couchbases://my-cbs-server?network=default"```
+
+              Will force the connection to ignore any alternative external addresses configured on the Couchbase Server node.
+
+              *Lost Connections*
 
               If the connection to Couchbase Server is lost during normal operations, Sync Gateway will automatically re-connect to another node in the cluster. During that re-connection period, the Sync Gateway will appear offline -- see [Taking Databases Offline](./../database-offline.html) -- and documents will not be replicated to mobile clients.
 

--- a/modules/ROOT/assets/attachments/sg.yaml
+++ b/modules/ROOT/assets/attachments/sg.yaml
@@ -649,15 +649,20 @@ properties:
 
               As with the SDK, when using the `couchbase://` or `couchbases://` schemes, the port is not required, but if specified should be the external/internal bucket ports (defaults are 11210 or 11207 respectively). Attempting to use the admin ports (8091/18091) will result in a startup error.
 
-              *Alternate Addresses*
+              **Alternate Addresses**
 
               On startup, Sync Gateway will try each hostname that is provided until it is able to connect successfully.
 
-              By default, if a remote cluster has an external address set, then when SG connects it will always use the external address.
+              By default, if a remote cluster has an external address set, then when SG connects it will apply a heuristic to determine whether to choose between external or default (internal) addresses.
+
+              The choice is based on the host names supplied in the connection string.
+              - SG uses external networking only when none of the supplied host names match any of Couchbase Server's internal node addresses, and an external address is defined.
+              - In all other cases Sync Gateway uses the default (internal) networking.
+
               However, it is possible to override this behavior by adding a `network` parameter to the connection string.
 
               The `network` parameter can be --
-              - auto -- this is the default value if no parameter is provided; there is no override
+              - auto -- this is the default value if no parameter is provided. In this case the heuristic described above is applied to determine the address used; so effectively there is no override.
               - external -- to always force use of the external address
               - default -- to always force use of the internal address
 
@@ -666,7 +671,7 @@ properties:
 
               Will force the connection to ignore any alternative external addresses configured on the Couchbase Server node.
 
-              *Lost Connections*
+              **Lost Connections**
 
               If the connection to Couchbase Server is lost during normal operations, Sync Gateway will automatically re-connect to another node in the cluster. During that re-connection period, the Sync Gateway will appear offline -- see [Taking Databases Offline](./../database-offline.html) -- and documents will not be replicated to mobile clients.
 


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-8078
Sync Gateway 2.8.1: DCP feed connections now support connstr ?network