### PR TITLE
DOC-7961 -- Suppress http headers

### DIFF
--- a/modules/ROOT/assets/attachments/sg.yaml
+++ b/modules/ROOT/assets/attachments/sg.yaml
@@ -613,7 +613,7 @@ properties:
                   admin_channels:
                     type: array
                     description: |
-                      The list of channels this role is automatically granted access to when Sync Gateway starts.  
+                      The list of channels this role is automatically granted access to when Sync Gateway starts.
                       If "*" is specified then the role is granted access to the star channel which contains all documents.
                     items:
                       type: string
@@ -1298,6 +1298,14 @@ properties:
       app_client_id:
         description: The Google App Client ID.
         type: string
+  hide_product_version:
+    description: |2
+      Determines whether product versions are removed from Server headers and REST API responses.
+      This setting does not apply to the Admin REST API.
+
+      This customization of the Sync Gateway response avoids revealing the version of the Sync Gateway to HTTP requests to the root path.
+    type: boolean
+    default: 'false'
   interface:
     description: Public REST API port.
     type: string

--- a/modules/ROOT/examples/configuration/sync-gateway-config.json
+++ b/modules/ROOT/examples/configuration/sync-gateway-config.json
@@ -55,7 +55,6 @@
 //
 {
   //  ... may be preceded by additional configuration data as required by the user ...
-  "log": ["*"],
   "databases": {
     "getting-started-db": {
       "server": "http://localhost:8091",
@@ -234,7 +233,6 @@
 {
   "interface":":5984",
   "adminInterface":":5985",
-  "log": ["*"],
   "logging": {
     "log_file_path": "/var/tmp/sglogs",
     "console": {
@@ -415,7 +413,6 @@ function sync(doc, oldDoc) {
 {
   "interface":":5984",
   "adminInterface":":5985",
-  "log": ["*"],
   "logging": {
     "log_file_path": "/var/tmp/sglogs",
     "console": {
@@ -692,7 +689,6 @@ function sync(doc, oldDoc) {
 {
   "interface":":5984",
   "adminInterface":":5985",
-  "log": ["*"],
   "logging": {
     "log_file_path": "/var/tmp/sglogs",
     "console": {


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-7961

Suppress headers in Sync Gateway HTTP responses.
As a developer, I should be able to customize the Sync Gateway response to the root path; typically so as not to reveal the version of the Sync Gateway to HTTP requests to the root path.