### PR TITLE
DOC-7144 -- warn about using the 'logs' directory

### DIFF
--- a/modules/ROOT/pages/_partials/block-caveats.adoc
+++ b/modules/ROOT/pages/_partials/block-caveats.adoc
@@ -123,3 +123,14 @@ This impacts Sync Gateway deployments running with shared bucket access enabled,
 --
 
 // end::cbs6.0ke-xattrs[]
+
+
+
+// tag::logfilefolderuse[]
+.Constraints
+[NOTE]
+--
+Do not use the `logs` directory as a storage location for files that should not be there. Permission issues with those files can prevent Sync Gateway from starting.
+--
+
+// end::logfilefolderuse[]

--- a/modules/ROOT/pages/advance/logging.adoc
+++ b/modules/ROOT/pages/advance/logging.adoc
@@ -24,6 +24,8 @@ include::partial$block-abstract.adoc[]
 
 // END Local attributes
 
+include::partial$block-caveats.adoc[tags=logfilefolderuse]
+
 // BEGIN Content
 == Overview
 Sync Gateway provides a robust <<lbl-continuous-logging>>{fn-clog} solution that delivers flexibility in terms of how logs are generated and retained, whilst also maintaining the level of logging required by Couchbase Support for investigation of issues.

--- a/modules/ROOT/pages/sgcollect-info.adoc
+++ b/modules/ROOT/pages/sgcollect-info.adoc
@@ -5,6 +5,8 @@ include::partial$_std-hdr-sgw.adoc[]
 :param-abstract: This page describes the command line statistics utility, `sgcollect`
 include::partial$block-abstract.adoc[]
 
+include::partial$block-caveats.adoc[tags=logfilefolderuse]
+
 == Overview
 `sgcollect_info` is command line utility that provides detailed statistics for a specific Sync Gateway node.
 This tool must be run on each node individually, not on all simultaneously.


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-7144

Need a warning about not writing non sync gateway owned files in the 'logs' directory.