### PR TITLE
DOC-8444-P2x6 -- Back Port - document compact_interval_days config it…

### DIFF
--- a/modules/ROOT/assets/attachments/sg.yaml
+++ b/modules/ROOT/assets/attachments/sg.yaml
@@ -1,4 +1,3 @@
-type: object
 properties:
   adminInterface:
     description: Port or TCP network address (IP address and the port) that the Admin REST API listens on. The loopback address prefix before the port (`127.0.0.1`) means the interface will not be reachable from other hosts. To make it reachable, change it to ":4985".
@@ -73,13 +72,26 @@ properties:
             default: the database name
           bucket_op_timeout_ms:
             type: integer
-            description: |
-              Configures how long Sync Gateway should wait for a bucket operation to complete before timing out and trying again. The value can be increased in scenarios where there is a heavy load on Couchbase Server and operations are likely to take more than 2.5 seconds to complete. The default value is 2500 milliseconds.
             default: 2500
+            description: |+
+              The ```bucket_op_timeout_ms``` value defines the period (in milliseconds) that Sync Gateway should wait for a bucket operation to complete before timing-out and trying again.
+
+              You can increase the period when there is a heavy load on Couchbase Server and operations are likely to take more than 2.5 seconds to complete.
+
+              The default value is 2500 milliseconds.
+          compact_interval_days:
+            type: integer
+            description: |+
+              The ```compact_interval_days``` value defines the interval (in days) between scheduled compaction runs.
+              It is a decimal number -- float32
+                - A Zero value means do not run compaction
+                - Minimum non-zero value -- 0.04 (approximately 1 hour)
+                - Maximum value -- 60 days
+                - Default -- 1 day
           delta_sync:
             type: object
-            description: |
-              *NOTE:* Delta Sync is an Enterprise Edition feature on Sync Gateway and Couchbase Lite.
+            description: |+
+              NOTE: Delta Sync is an Enterprise Edition feature on Sync Gateway and Couchbase Lite.
 
               Delta Sync is the ability to replicate only parts of the Couchbase mobile document that have changed. This can result in significant savings in bandwidth consumption as well as throughput improvements, especially when network bandwidth is typically constrained.
 


### PR DESCRIPTION
…em (#508)

https://issues.couchbase.com/browse/DOC-8444

document databases.{db}.compact_interval_days config option, missing since introduction at 2.6

(cherry picked from commit 00169c96f695471ed35af1b11e31cf973e9f75fa)
(cherry picked from commit ed78b6ea1b2c27424b342938b381d