### PR TITLE
Update get-started-verify-install.adoc

### DIFF
--- a/modules/ROOT/pages/get-started-verify-install.adoc
+++ b/modules/ROOT/pages/get-started-verify-install.adoc
@@ -65,7 +65,7 @@ The configuration points to the `get-started-bucket` which we will use to verify
       "server": "http://127.0.0.1:8091",
       "bucket": "get-started-bucket", // <.>
       "username": "sync_gateway", // <.>
-      "password": "password", //
+      "password": "password",
       "enable_shared_bucket_access": true, // <.>
       "import_docs": true, // <.>
       "num_index_replicas": 0, // <.>


### PR DESCRIPTION
The additional '//' in the code is causing the below error 
```
➜  sync config.json 
2022-01-13T02:28:47.678-08:00 [ERR] Error reading config file config.json: rest.ServerConfig.Databases: rest.DbConfig.ReadString: expects " or n, but found /, error found in #10 byte of ...|ssword", //
      "e|..., bigger context ...|: "sync_gateway", 
      "password": "password", //
      "enable_shared_bucket_access": true, 
    |... -- rest.ServerMain() at config.go:1206
```