### PR TITLE
DOC-10072-3.0: Missing Couchbase 7.1 in compatibility document

### DIFF
--- a/modules/ROOT/pages/_partials/sgw-svr-compatibility.adoc
+++ b/modules/ROOT/pages/_partials/sgw-svr-compatibility.adoc
@@ -63,7 +63,7 @@ Compatibility Matrix
 2+^.>|Sync Gateway ↓
 4+|Couchbase Server →
 ^.>| Version ^.>| Scenario
-^.>| 5.0  *{fn3-0}* ^.>| 5.1  *{fnref3-0}* ^.>| 5.5-6.6|7.0
+^.>| 5.0  *{fn3-0}* ^.>| 5.1  *{fnref3-0}* ^.>| 5.5-6.6|7.0-7.1
 
 | 1.4 *{fn-eos-sgw}*
 | `feed_type: "DCP"`


### PR DESCRIPTION
Adding 7.1 to compatibility table