### PR TITLE
3.0.3 replaces .0

### DIFF
--- a/modules/ROOT/pages/_partials/compatibility-cbl-sgw.adoc
+++ b/modules/ROOT/pages/_partials/compatibility-cbl-sgw.adoc
@@ -36,7 +36,7 @@ The table below summarizes the compatible versions of Couchbase Lite with Sync G
 | 2.0
 | 2.1
 | 2.5 - 2.8
-|  3.0.0 ()
+|  3.0.3 ()
 
 | 1.4 *{fn-eos-sgw}* and 1.5 *{fn-eol-sgw}*
 | image:ROOT:yes.png[]
@@ -68,7 +68,7 @@ with delta sync enabled
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 
-|  3.0.0
+|  3.0.3
 | image:ROOT:no.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]

--- a/modules/ROOT/pages/_partials/sgw-svr-compatibility.adoc
+++ b/modules/ROOT/pages/_partials/sgw-svr-compatibility.adoc
@@ -144,7 +144,7 @@ Compatibility Matrix
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 
-| 3.0.0
+| 3.0.3
 |
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -58,6 +58,13 @@ The migration to 3.0 configuration is a ONE WAY process -- see: {upgrading--xref
 == 3.0.3 -- June 2022
 
 Version 3.0.3 of {sgw} delivers a number of fixes and enhancements.
+.Version 3.0.3 replaces v3.0.0
+[IMPORTANT]
+--
+This version of {sgw} includes fixes for several critical issues from v3.0.0. Therefore 
+v3.0.0 is replaced by v3.0.3.
+If you are using v3.0.0 we strongly recommend upgrading to v3.0.3.
+--
 
 === Enhancements
 
@@ -113,10 +120,12 @@ Quicklinks::
 <<issues-and-resolutions-300>> *|*
 <<support-notices-300>>
 
-.Upgrade to 3.0.3
-[NOTE]
+.Replaced by v3.0.3
+[IMPORTANT]
 --
-Upgrading to version 3.0.3 is strongly recommended.
+Version 3.0.3 includes fixes for several critical issues found in 3.0.0. 
+Therefore v3.0.0 is replaced by v3.0.3. We strongly encourage upgrading to
+v3.0.3.
 --
 
 [#new-features-300]


### PR DESCRIPTION
Add notes to the release notes and update the compatibility tables to show that v3.0.0 is replaced by v3.0.3.