### PR TITLE
replace 3.0.0 with 3.0.3

### DIFF
--- a/modules/ROOT/pages/get-started-install.adoc
+++ b/modules/ROOT/pages/get-started-install.adoc
@@ -16,7 +16,7 @@ include::partial$_set_page_context.adoc[]
 :is-prepare!:
 :is-install!:
 :is-verify!:
-// :this-release: 3.0.0
+// :this-release: 3.0.3
 
 :downloads--url: {downloads-mobile--xref}
 :sg_download_link: pass:q,a[{url-package-downloads}/{version-maintenance}/]


### PR DESCRIPTION
Replace all instance of 3.0.0 in the documentation with 3.0.x or 3.0.3, as appropriate.