### PR TITLE
[DOC-10271] Sync Gateway 3.0.0+ is incompatible with CB Server <6.5.0

### DIFF
--- a/modules/ROOT/pages/_partials/sgw-svr-compatibility.adoc
+++ b/modules/ROOT/pages/_partials/sgw-svr-compatibility.adoc
@@ -157,9 +157,9 @@ Compatibility Matrix
 
 | 3.0.3
 |
-| image:ROOT:yes.png[]
-| image:ROOT:yes.png[]
-| image:ROOT:yes.png[]
+| image:ROOT:no.png[]
+| image:ROOT:no.png[]
+| image:ROOT:no.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 // |1.3{fnref-eos-sgw}

--- a/modules/ROOT/pages/_partials/sgw-svr-compatibility.adoc
+++ b/modules/ROOT/pages/_partials/sgw-svr-compatibility.adoc
@@ -63,7 +63,7 @@ Compatibility Matrix
 2+^.>|Sync Gateway ↓
 5+^|Couchbase Server →
 ^.>| Version ^.>| Scenario
-^.>| 5.0  *{fn3-0}* ^.>| 5.1  *{fnref3-0}* ^.>| 5.5-6.6|7.0|7.1
+^.>| 5.0  *{fn3-0}* ^.>| 5.1  *{fnref3-0}* ^.>| 5.5-6.0|6.5-7.0|7.1
 
 | 1.4 *{fn-eos-sgw}*
 | `feed_type: "DCP"`


### PR DESCRIPTION
Changed table to show that CB < 6.6 is incompatible with SGW 3.0x