### PR TITLE
Correct invalid JSON in verify installation curl command

### DIFF
--- a/modules/ROOT/pages/get-started-verify-install.adoc
+++ b/modules/ROOT/pages/get-started-verify-install.adoc
@@ -205,7 +205,7 @@ curl  --location -g --request POST 'http://localhost:4985/traveldb/_user/' \// <
       --data-raw '{
           "name": "sgwuser1", // <.>
           "password": "passwordstring",
-          "roles": ["stdrole"] // <.>
+          "roles": ["stdrole"], // <.>
           "admin_channels": ["public"] // <.>
       }'
 ----

--- a/modules/ROOT/pages/get-started-verify-install.adoc
+++ b/modules/ROOT/pages/get-started-verify-install.adoc
@@ -205,7 +205,7 @@ curl  --location -g --request POST 'http://localhost:4985/traveldb/_user/' \// <
       --data-raw '{
           "name": "sgwuser1", // <.>
           "password": "passwordstring",
-          "roles": ["stdrole"], // <.>
+          "admin_roles": ["stdrole"], // <.>
           "admin_channels": ["public"] // <.>
       }'
 ----


### PR DESCRIPTION
This example is missing a comma resulting in invalid JSON

https://docs.couchbase.com/sync-gateway/current/get-started-verify-install.html#add-the-user 