### PR TITLE
DOC-10471: Changed bootstrap_config to bootstrap for SG startup config schema

### DIFF
--- a/modules/ROOT/assets/attachments/rest-api-admin.yaml
+++ b/modules/ROOT/assets/attachments/rest-api-admin.yaml
@@ -2510,7 +2510,7 @@ definitions:
       Sync Gateway's start-up configuration properties
     properties:
 
-      bootstrap_config:
+      bootstrap:
         type: object
         title: Bootstrap configuration
         description: Define fundamental bootstrap related configuration properties

--- a/modules/ROOT/assets/attachments/sg-Bootstrap_model.yaml
+++ b/modules/ROOT/assets/attachments/sg-Bootstrap_model.yaml
@@ -4,7 +4,7 @@ description: 'Sync Gateway''s start-up configuration properties
 
   '
 properties:
-  bootstrap_config:
+  bootstrap:
     type: object
     title: Bootstrap configuration
     description: Define fundamental bootstrap related configuration properties

--- a/modules/ROOT/pages/_partials/static_restapi/admin/definitions.adoc
+++ b/modules/ROOT/pages/_partials/static_restapi/admin/definitions.adoc
@@ -17,7 +17,7 @@ Sync Gateway's start-up configuration properties
 __optional__|Define API related configuration properties|<<_api_configuration,API configuration>>
 |**auth** +
 __optional__|Define Auth related configuration properties|<<_auth_configuration,Auth configuration>>
-|**bootstrap_config** +
+|**bootstrap** +
 __optional__|Define fundamental bootstrap related configuration properties|<<_bootstrap_configuration,Bootstrap configuration>>
 |**logging** +
 __optional__|Define logging configuration|<<_logging_model,Logging_model>>


### PR DESCRIPTION
[DOC-10471](https://issues.couchbase.com/browse/DOC-10471)

Changed the startup config option `bootstrap_config`to the valid startup config option `bootstrap`.

This will fix the invalid startup config schema on https://docs.couchbase.com/sync-gateway/current/configuration-schema-bootstrap.html#lbl-schema 