### PR TITLE
DOC-10399: Updates Sync Metadata Example

### DIFF
--- a/modules/ROOT/pages/sync-with-couchbase-server.adoc
+++ b/modules/ROOT/pages/sync-with-couchbase-server.adoc
@@ -133,7 +133,7 @@ The N1QL query language {fnref-cbs5x0} supports the ability to query these exten
 ====
 [source,sql]
 ----
-SELECT meta().xattrs._sync FROM `travel-sample` WHERE meta().id = "mydocId"
+SELECT meta().xattrs._sync FROM scope.collection WHERE meta().id = "mydocId"
 ----
 ====
 


### PR DESCRIPTION
Updates Sync Metadata Example _from_:

`SELECT meta().xattrs._sync FROM travel-sample WHERE meta().id = "mydocId"`

_to_

`SELECT meta().xattrs._sync FROM scope.collection WHERE meta().id = "mydocId"`