### PR TITLE
Updates Legacy Config Important Notification

### DIFF
--- a/modules/ROOT/pages/configuration-properties-legacy.adoc
+++ b/modules/ROOT/pages/configuration-properties-legacy.adoc
@@ -22,7 +22,8 @@ include::partial$_show_page_header_block.adoc[]
 // END -- DO NOT EDIT
 
 .Legacy Configuration
-IMPORTANT: You cannot use `collections` in Sync Gateway’s legacy Pre-3.0 configuration method. For current configuration details, see: {configuration-overview--xref} and-or {configuration-schema-bootstrap--xref}.
+IMPORTANT: You cannot use `collections` in Sync Gateway’s legacy Pre-3.0 configuration method. 
+For current configuration details, see: {configuration-overview--xref} and-or {configuration-schema-bootstrap--xref}.
 
 == Introduction
 

--- a/modules/ROOT/pages/configuration-properties-legacy.adoc
+++ b/modules/ROOT/pages/configuration-properties-legacy.adoc
@@ -22,7 +22,7 @@ include::partial$_show_page_header_block.adoc[]
 // END -- DO NOT EDIT
 
 .Legacy Configuration
-IMPORTANT: This page describes Sync Gateway's legacy Pre-3.0 configuration method -- for current configuration details -- see: {configuration-overview--xref} and-or {configuration-schema-bootstrap--xref}.
+IMPORTANT: You cannot use `collections` in Sync Gateway’s legacy Pre-3.0 configuration method. For current configuration details, see: {configuration-overview--xref} and-or {configuration-schema-bootstrap--xref}.
 
 == Introduction
 


### PR DESCRIPTION
Updates 'Legacy Pre-3.0 Configuration' page to inform users they can't use `collections` (while using Legacy Pre-3.0 Configuration)


