### PR TITLE
DOC-10403: Adds examples to access control pages

### DIFF
--- a/modules/ROOT/pages/_partials/concepts/access-control-model.adoc
+++ b/modules/ROOT/pages/_partials/concepts/access-control-model.adoc
@@ -28,6 +28,74 @@ Like the channel, a role is granted access to zero, one or more channels.
 
 A user can only read documents that are in at least one of their assigned channels; whether directly or as part of an assigned role.
 
+[#ex-sync-function-model]
+== Sync Function Examples
+
+Couchbase Sync Gateway defines a Sync Function at the `collection` level. 
+Defining at this level helps simplify data management and improve data reliability. 
+Each collection in the system allows for only one Sync Function, which enables the specification of Access Control rules.
+
+.Default Sync Function
+====
+
+=====
+--
+
+[source, javascript]
+----
+function (doc, oldDoc, meta) { 
+   channel(CollectionName); 
+
+}
+----
+Here the function then calls the `channel` and passes in the name of the collection `(CollectionsName)` as an argument.
+
+By default, every document in the collection is automatically assigned to a channel with the same name as the collection. This system automatically creates a channel with the collection's name. The assignment of all documents to the collection channel is functionally similar to assigning them to the xref:2.7@sync-gateway-channels.adoc#star-channel[Star Channel].
+
+To override this, use a custom sync function or a Specified Default Sync Function.
+
+
+=====
+
+====
+
+.Specified Default Sync Function
+====
+
+=====
+--
+
+[source, javascript]
+----
+function (doc, oldDoc, meta) {
+channel(doc.channels);
+
+} 
+----
+Here is the default Sync Function when the default `scope` and default `collection` is clearly specified.
+
+=====
+
+====
+
+.Upgraded Default Sync Function
+====
+
+=====
+--
+
+[source, javascript]
+----
+function (doc, oldDoc, meta) {
+channel(doc.channels);
+
+} 
+----
+Here is the default Sync Function when you have upgraded; it remains the same as the previous version.
+
+=====
+
+====
 
 == Context
 You control document access by routing it to a channel and by making that channel accessible to the users or roles you want to be able to access documents of that type.

--- a/modules/ROOT/pages/_partials/concepts/channels.adoc
+++ b/modules/ROOT/pages/_partials/concepts/channels.adoc
@@ -28,6 +28,74 @@ You typically will use channels to:
 
 Sync Gateway provides two special channels and a channel wildcard character.
 
+[#ex-sync-function-examples]
+== Sync Function Examples
+
+Couchbase Sync Gateway defines a Sync Function at the `collection` level. 
+Defining at this level helps simplify data management and improve data reliability. 
+Each collection in the system allows for only one Sync Function, which enables the specification of Access Control rules.
+
+.Default Sync Function
+====
+
+=====
+--
+
+[source, javascript]
+----
+function (doc, oldDoc, meta) { 
+   channel(CollectionName); 
+
+}
+----
+Here the function then calls the `channel` and passes in the name of the collection `(CollectionsName)` as an argument.
+
+By default, every document in the collection is automatically assigned to a channel with the same name as the collection. This system automatically creates a channel with the collection's name. The assignment of all documents to the collection channel is functionally similar to assigning them to the xref:2.7@sync-gateway-channels.adoc#star-channel[Star Channel].
+
+To override this, use a custom sync function or a Specified Default Sync Function.
+
+
+=====
+
+====
+
+.Specified Default Sync Function
+====
+
+=====
+--
+
+[source, javascript]
+----
+function (doc, oldDoc, meta) {
+channel(doc.channels);
+
+} 
+----
+Here is the default Sync Function when the default `scope` and default `collection` is clearly specified.
+
+=====
+
+====
+
+.Upgraded Default Sync Function
+====
+
+=====
+--
+
+[source, javascript]
+----
+function (doc, oldDoc, meta) {
+channel(doc.channels);
+
+} 
+----
+Here is the default Sync Function when you have upgraded; it remains the same as the previous version.
+
+=====
+
+====
 
 [#lbl-usecase]
 == Use Case

--- a/modules/ROOT/pages/_partials/sync-api/sync-function-api-channel.adoc
+++ b/modules/ROOT/pages/_partials/sync-api/sync-function-api-channel.adoc
@@ -30,6 +30,74 @@ include::partial$sync-api/syncargs.adoc[tags=args;args-channel]
 
 // |===
 
+[#ex-sync-function-API-channel]
+== Sync Function Examples
+
+Couchbase Sync Gateway defines a Sync Function at the `collection` level. 
+Defining at this level helps simplify data management and improve data reliability. 
+Each collection in the system allows for only one Sync Function, which enables the specification of Access Control rules.
+
+.Default Sync Function
+====
+
+=====
+--
+
+[source, javascript]
+----
+function (doc, oldDoc, meta) { 
+   channel(CollectionName); 
+
+}
+----
+Here the function then calls the `channel` and passes in the name of the collection `(CollectionsName)` as an argument.
+
+By default, every document in the collection is automatically assigned to a channel with the same name as the collection. This system automatically creates a channel with the collection's name. The assignment of all documents to the collection channel is functionally similar to assigning them to the xref:2.7@sync-gateway-channels.adoc#star-channel[Star Channel].
+
+To override this, use a custom sync function or a Specified Default Sync Function.
+
+
+=====
+
+====
+
+.Specified Default Sync Function
+====
+
+=====
+--
+
+[source, javascript]
+----
+function (doc, oldDoc, meta) {
+channel(doc.channels);
+
+} 
+----
+Here is the default Sync Function when the default `scope` and default `collection` is clearly specified.
+
+=====
+
+====
+
+.Upgraded Default Sync Function
+====
+
+=====
+--
+
+[source, javascript]
+----
+function (doc, oldDoc, meta) {
+channel(doc.channels);
+
+} 
+----
+Here is the default Sync Function when you have upgraded; it remains the same as the previous version.
+
+=====
+
+====
 
 == Context
 

--- a/modules/ROOT/pages/auto-purge-channel-access-revocation.adoc
+++ b/modules/ROOT/pages/auto-purge-channel-access-revocation.adoc
@@ -241,6 +241,75 @@ Subsequent changes to previously rejected documents are automatically pushed up.
 
 ====
 
+[#ex-sync-function-auto-purge]
+== Sync Function Examples
+
+Couchbase Sync Gateway defines a Sync Function at the `collection` level. 
+Defining at this level helps simplify data management and improve data reliability. 
+Each collection in the system allows for only one Sync Function, which enables the specification of Access Control rules.
+
+.Default Sync Function
+====
+
+=====
+--
+
+[source, javascript]
+----
+function (doc, oldDoc, meta) { 
+   channel(CollectionName); 
+
+}
+----
+Here the function then calls the `channel` and passes in the name of the collection `(CollectionsName)` as an argument.
+
+By default, every document in the collection is automatically assigned to a channel with the same name as the collection. This system automatically creates a channel with the collection's name. The assignment of all documents to the collection channel is functionally similar to assigning them to the xref:2.7@sync-gateway-channels.adoc#star-channel[Star Channel].
+
+To override this, use a custom sync function or a Specified Default Sync Function.
+
+
+=====
+
+====
+
+.Specified Default Sync Function
+====
+
+=====
+--
+
+[source, javascript]
+----
+function (doc, oldDoc, meta) {
+channel(doc.channels);
+
+} 
+----
+Here is the default Sync Function when the default `scope` and default `collection` is clearly specified.
+
+=====
+
+====
+
+.Upgraded Default Sync Function
+====
+
+=====
+--
+
+[source, javascript]
+----
+function (doc, oldDoc, meta) {
+channel(doc.channels);
+
+} 
+----
+Here is the default Sync Function when you have upgraded; it remains the same as the previous version.
+
+=====
+
+====
+
 // BEGIN -- Page Footer
 include::partial$block-related-content-sync.adoc[]
 // END -- Page Footer


### PR DESCRIPTION
Adds examples to the following pages:

- channels
- access control model
- sync function overview
- sync function API