### PR TITLE
Doc 10993  Review mobile helium docs

### DIFF
--- a/modules/ROOT/pages/_partials/concepts/access-control-model.adoc
+++ b/modules/ROOT/pages/_partials/concepts/access-control-model.adoc
@@ -54,26 +54,6 @@ By default, every document in the collection is automatically assigned to a chan
 
 To override this, use a custom sync function or a Specified Default Sync Function.
 
-
-=====
-
-====
-
-.Specified Default Sync Function
-====
-
-=====
---
-
-[source, javascript]
-----
-function (doc, oldDoc, meta) {
-channel(doc.channels);
-
-} 
-----
-Here is the default Sync Function when the default `scope` and default `collection` is clearly specified.
-
 =====
 
 ====

--- a/modules/ROOT/pages/_partials/concepts/channels.adoc
+++ b/modules/ROOT/pages/_partials/concepts/channels.adoc
@@ -59,25 +59,6 @@ To override this, use a custom sync function or a Specified Default Sync Functio
 
 ====
 
-.Specified Default Sync Function
-====
-
-=====
---
-
-[source, javascript]
-----
-function (doc, oldDoc, meta) {
-channel(doc.channels);
-
-} 
-----
-Here is the default Sync Function when the default `scope` and default `collection` is clearly specified.
-
-=====
-
-====
-
 .Upgraded Default Sync Function
 ====
 

--- a/modules/ROOT/pages/_partials/concepts/sync-function.adoc
+++ b/modules/ROOT/pages/_partials/concepts/sync-function.adoc
@@ -65,28 +65,6 @@ By default, every document in the collection is automatically assigned to a chan
 
 To override this, use a custom sync function or a Specified Default Sync Function.
 
-
-=====
-
-====
-
-.Specified Default Sync Function
-====
-
-=====
---
-
-[source, javascript]
-----
-function (doc, oldDoc, meta) {
-channel(doc.channels);
-
-} 
-----
-Here is the default Sync Function when the default `scope` and default `collection` is clearly specified.
-
-=====
-
 ====
 
 .Upgraded Default Sync Function

--- a/modules/ROOT/pages/_partials/sync-api/sync-function-api-channel.adoc
+++ b/modules/ROOT/pages/_partials/sync-api/sync-function-api-channel.adoc
@@ -61,25 +61,6 @@ To override this, use a custom sync function or a Specified Default Sync Functio
 
 ====
 
-.Specified Default Sync Function
-====
-
-=====
---
-
-[source, javascript]
-----
-function (doc, oldDoc, meta) {
-channel(doc.channels);
-
-} 
-----
-Here is the default Sync Function when the default `scope` and default `collection` is clearly specified.
-
-=====
-
-====
-
 .Upgraded Default Sync Function
 ====
 

--- a/modules/ROOT/pages/auto-purge-channel-access-revocation.adoc
+++ b/modules/ROOT/pages/auto-purge-channel-access-revocation.adoc
@@ -267,26 +267,6 @@ By default, every document in the collection is automatically assigned to a chan
 
 To override this, use a custom sync function or a Specified Default Sync Function.
 
-
-=====
-
-====
-
-.Specified Default Sync Function
-====
-
-=====
---
-
-[source, javascript]
-----
-function (doc, oldDoc, meta) {
-channel(doc.channels);
-
-} 
-----
-Here is the default Sync Function when the default `scope` and default `collection` is clearly specified.
-
 =====
 
 ====

--- a/modules/ROOT/pages/configuration-schema-access-control.adoc
+++ b/modules/ROOT/pages/configuration-schema-access-control.adoc
@@ -15,7 +15,7 @@ include::{concepts}sync-function.adoc[tags=summary]
 
 ----
 
-https:://{sgw-uri}/{db}/_config/sync
+https:://{sgw-uri}/{keyspace}/_config/sync
 
 ----
 

--- a/modules/ROOT/pages/configuration-schema-db-security.adoc
+++ b/modules/ROOT/pages/configuration-schema-db-security.adoc
@@ -21,7 +21,7 @@ include::partial$block-caveats.adoc[tags="legacy-config-equivalents"]
 
 == Introduction
 
-In 3.0 we use the Admin REST API `_user` and `_role` endpoints to provision and manage {sgw} users through persistent configuration changes.
+We use the Admin REST API `_user` and `_role` endpoints to provision and manage {sgw} users through persistent configuration changes.
 
 This content introduces the <<lbl-upsert-role>> and <<lbl-upsert-user>> endpoints for convenience -- see {rest-api-admin--xref--database-security} for a full description of the endpoints available.
 

--- a/modules/ROOT/pages/data-modeling.adoc
+++ b/modules/ROOT/pages/data-modeling.adoc
@@ -139,7 +139,7 @@ You can organize your documents in collections to logically group categories of 
 
 You can organize your collections in scopes according to content-type or deployment-phase.
 
-xref:server:learn:data/scopes-and-collections.adoc[Couchbase Scopes and Collections for Server]
+xref:server:learn:data:scopes-and-collections.adoc[Couchbase Scopes and Collections for Server]
 
 xref:couchbase-lite:java:scopes-collections-manage.adoc[Couchbase Scopes and Collections for Couchbase Lite]
 


### PR DESCRIPTION
Reviews and corrects feedback on the following:

DOC-10993: Removes incorrect function from Sync Function page

DOC-10993: Removes incorrect function from Auto-Purge page
 
DOC-10993: Removes incorrect function from Acess Control page
 
DOC-10993: Removes incorrect function from Channels page
 
DOC-10993: Removes incorrect function from Sync-Function-API page
 
DOC-10993: Corrects typo
 
DOC-10993: Adds /{keyspace}/ in the place of /{db}/

DOC-10993: Fixes link syntax - must check in preview also