### PR TITLE
CBG-2878: Relnotes 3.0.7

### DIFF
--- a/modules/ROOT/pages/_partials/release_notes/sync-gateway-3-0-7-release-note.adoc
+++ b/modules/ROOT/pages/_partials/release_notes/sync-gateway-3-0-7-release-note.adoc
@@ -1,0 +1,23 @@
+[#maint-3-0-7]
+== 3.0.7 -- May 2023
+
+=== New Features
+
+* https://issues.couchbase.com/browse/CBG-2846[++ CBG-2846 -- Ability to define CORS as part of DB config ++]
+
+
+=== Enhancements
+
+* https://issues.couchbase.com/browse/CBG-2841[++ CBG-2841 -- Add a flag to sg-collect collection to delete zip once uploaded++]
+
+
+=== Issues and Resolutions
+
+==== Fixed Issues
+
+* https://issues.couchbase.com/browse/CBG-2850[++ CBG-2850  -- Avoid leaking information about database existence on public API]
+
+
+==== Known Issues
+
+None for this release

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -43,20 +43,24 @@ The migration to 3.0 configuration is a ONE WAY process -- see: {upgrading--xref
 --
 
 
-// BEGIN MAINTENANCE RELEASE BLOCK
-//
-// Clone this block for each maintenance release.
-// Edit release nos as required
-// Satisfy, or remove the `showme` conditional to unhide this block
-// :showme:
-
-// ifdef::showme[]
-:param-release-tag: -3-0-3
+////////////////////////
+// UPDATE THIS BIT HERE: e.g. add include:: to new partial for the version.
+////////////////////////
 
 [#maint-latest]
+include::partial$release_notes/sync-gateway-3-0-7-release-note.adoc[]
 include::partial$release_notes/sync-gateway-3-0-5-release-note.adoc[]
 include::partial$release_notes/sync-gateway-3-0-4-release-note.adoc[]
 
+
+
+
+
+////////////////////////
+// The following is LEGACY markup that we don't understand well.
+////////////////////////
+
+:param-release-tag: -3-0-3
 [#maint-3-0-3]
 == 3.0.3 -- June 2022
 


### PR DESCRIPTION
@djpongh I'm a bit confused, https://issues.couchbase.com/browse/CBG-2878 your comment there and previously suggests we could reuse the relnotes for 3.0.6?

But the tickets linked against that ticket look slightly different. Can you have a quick look and confirm where I need to look for tickets if the PR'd version isn't correct?