### PR TITLE
DOC-11070: Updates link for new S&C page

### DIFF
--- a/modules/ROOT/pages/whatsnew.adoc
+++ b/modules/ROOT/pages/whatsnew.adoc
@@ -24,7 +24,7 @@ Users should be able to upgrade to 3.1.x from 3.0.x without manual intervention.
 == Overview of {sgw-t} 3.1.0
 
 // tag::scopes-and-collections[]
-Couchbase Sync Gateway now provides advanced cloud-to-edge support for xref:data-modeling.adoc#Scopes-and-Collections[Scopes and Collections]. This will provide seamless synchronization and efficient data management across distributed environments, from cloud infrastructure to edge devices.
+Couchbase Sync Gateway now provides advanced cloud-to-edge support for xref:scopes-and-collections.adoc[Scopes and Collections]. This will provide seamless synchronization and efficient data management across distributed environments, from cloud infrastructure to edge devices.
 
 Scopes and Collections enable mobile and edge devices to benefit from:
 


### PR DESCRIPTION
Updates the S&C link in the _New In 3.1_ page to the new Scopes and Collections page.

https://issues.couchbase.com/browse/DOC-11070