### PR TITLE
DOC-11100: Creates warning to the user re: use_view availability

### DIFF
--- a/modules/ROOT/pages/_partials/sgw-svr-compatibility.adoc
+++ b/modules/ROOT/pages/_partials/sgw-svr-compatibility.adoc
@@ -183,10 +183,10 @@ Compatibility Matrix
 
 [WARNING]
 ====
-Starting from CBS 7.0, the `use_views` feature is no longer available.
+Starting from CBS 7.0, the use_views feature is deprecated.
 
-* SGW 3.1 will *still* run with `use_views` using a `default scope/default collection` configuration
-* SGW 3.1 will *not* run `use_views` using a `custom scope/custom collection` configuration
+* SGW 3.1 will only run with `use_views` with a default scope/collection configuration
+* You cannot run `use_views` with a defined scope/collection
 ====
 
 

--- a/modules/ROOT/pages/_partials/sgw-svr-compatibility.adoc
+++ b/modules/ROOT/pages/_partials/sgw-svr-compatibility.adoc
@@ -181,6 +181,15 @@ Compatibility Matrix
 
 |===
 
+[WARNING]
+====
+Starting from CBS 7.0, the `use_views` feature is no longer available.
+
+* SGW 3.1 will *still* run with `use_views` using a `default scope/default collection` configuration
+* SGW 3.1 will *not* run `use_views` using a `custom scope/custom collection` configuration
+====
+
+
 include::partial$block-caveats.adoc[tags="ephemeral-buckets"]
 
 // For all of the above, the Couchbase Server xref:server:learn:buckets-memory-and-storage/buckets.adoc[bucket type] must be *Couchbase*.


### PR DESCRIPTION
- Creates warning stating `use_views` have been depricated 
