### PR TITLE
Doc 11122:  Links Metrics REST API page  to View Statistics and Metrics page 

### DIFF
--- a/modules/ROOT/pages/rest-api-metrics.adoc
+++ b/modules/ROOT/pages/rest-api-metrics.adoc
@@ -48,7 +48,8 @@ include::partial$prometheus-activation.adoc[]
 You can browse the API using the explorer below.
 The explorer groups all the endpoints by functionality.
 Just click a label to expand the endpoints.
-You can also generate curl requests if required, for each endpoint.
+For more information, refer to xref:stats-monitoring.adoc[View Statistics and Metrics].
+You can also generate curl requests if required, for each endpoint:
 
 swagger_ui::_attachments/bundled-metric.yaml[]
 


### PR DESCRIPTION
Links Metrics REST API page  to View Statistics and Metrics page 

[DOC-11122](https://issues.couchbase.com/browse/DOC-11122)