### PR TITLE
DOC-11306: Improve 3.1.1-relnote format

### DIFF
--- a/modules/ROOT/pages/_partials/release_notes/sync-gateway-3-1-1-release-note.adoc
+++ b/modules/ROOT/pages/_partials/release_notes/sync-gateway-3-1-1-release-note.adoc
@@ -2,12 +2,7 @@
 
 Version 3.1.1 of Sync Gateway delivers the following features and enhancements:
 
-=== Scopes and Collections
-
-include::ROOT:whatsnew.adoc[tag=scopes-and-collections]
-
-
-[#maint-3-1-0]
+[#maint-3-1-1]
 === Enhancements
 
 * https://issues.couchbase.com/browse/CBG-3147[CBG-3147 - Avoid unnecessary resync on upgrade to 3.1]

--- a/modules/ROOT/pages/_partials/release_notes/sync-gateway-3-1-1-release-note.adoc
+++ b/modules/ROOT/pages/_partials/release_notes/sync-gateway-3-1-1-release-note.adoc
@@ -2,6 +2,8 @@
 
 Version 3.1.1 of Sync Gateway delivers the following features and enhancements:
 
+NOTE: For an overview of the latest features offered in Sync Gateway 3.1, see xref:whatsnew.adoc[New in 3.1].
+
 [#maint-3-1-1]
 === Enhancements
 

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -47,6 +47,7 @@ The migration to 3.x configuration is a ONE WAY process -- see: {upgrading--xref
 
 [#maint-latest]
 include::partial$release_notes/sync-gateway-3-1-1-release-note.adoc[]
+
 include::partial$release_notes/sync-gateway-3-1-0-release-note.adoc[]
 
 


### PR DESCRIPTION
- Removes the tag from 3.1.1 -- linking to the 'New in 3.1' page
- Per feedback from @djpongh 
- Keeps the tag for 3.10
- Jira [DOC-11306](https://issues.couchbase.com/browse/DOC-11306)