### PR TITLE
DOC-11735: Correct HTTP verb

### DIFF
--- a/modules/ROOT/pages/_partials/howto/how-to-use-xattrs-for-access-grants.adoc
+++ b/modules/ROOT/pages/_partials/howto/how-to-use-xattrs-for-access-grants.adoc
@@ -58,7 +58,7 @@ CURL::
 --
 [source, json]
 ----
-curl -X PUT 'http://localhost:4985/hotels/_config' \
+curl -X POST 'http://localhost:4985/hotels/_config' \
 --header 'Accept: application/json' \
 --header 'Content-Type: application/json' \
 --data-raw '{
@@ -76,7 +76,7 @@ HTTP::
 
 [source, http]
 ----
-PUT /hotels/_config HTTP/1.1
+POST /hotels/_config HTTP/1.1
 Host: http://localhost:4985
 Accept: application/json
 Content-Type: application/json


### PR DESCRIPTION
This pull request: https://issues.couchbase.com/browse/DOC-11735

Fixes example 1 here: https://docs.couchbase.com/sync-gateway/current/access-control-how-use-xattrs-for-access-grants.html

Ticket Description: As discovered by [Alfred Nketia](https://issues.couchbase.com/secure/ViewProfile.jspa?name=alfred.nketia), in example 1 on https://docs.couchbase.com/sync-gateway/current/access-control-how-use-xattrs-for-access-grants.html this needs to be POST instead of PUT.

POST indicates a partial update to the config, but PUT is a full replacement of the config.