### PR TITLE
DOC-11517: correct port for create new document

### DIFF
--- a/modules/ROOT/pages/get-started-verify-install.adoc
+++ b/modules/ROOT/pages/get-started-verify-install.adoc
@@ -272,7 +272,7 @@ Within a terminal use CURL to issue the following POST request, which adds a new
 ----
 DIGEST=`echo -n sgwuser1:password | base64`
 
-curl  --location --request PUT 'http://localhost:4985/traveldb/hotel_88801' \
+curl  --location --request PUT 'http://localhost:4984/traveldb/hotel_88801' \
       --header "Authorization: Basic $DIGEST" \
       --header 'Content-Type: application/json' \
       --data-raw '{

--- a/modules/ROOT/pages/get-started-verify-install.adoc
+++ b/modules/ROOT/pages/get-started-verify-install.adoc
@@ -322,7 +322,7 @@ image::cbs-view-first-doc.png[]
 .Request
 [{snippet-header}]
 ----
-curl  --location --request GET 'http://localhost:4985/traveldb/hotel_88801' \
+curl  --location --request GET 'http://localhost:4984/traveldb/hotel_88801' \
       --header "Authorization: Basic $DIGEST"
 ----
 
@@ -348,7 +348,7 @@ curl  --location --request GET 'http://localhost:4985/traveldb/hotel_88801' \
 [{snippet-header}]
 ----
 curl  --location -g \
-      --request PUT 'http://localhost:4985/traveldb/hotel_88801?new_edits=true&rev=1-f28b5cc13a38892f4f85913d4e654270' \// <.>
+      --request PUT 'http://localhost:4984/traveldb/hotel_88801?new_edits=true&rev=1-f28b5cc13a38892f4f85913d4e654270' \// <.>
       --header 'Accept: application/json' \
       --header 'Content-Type: application/json' \
       --data-raw '{
@@ -415,7 +415,7 @@ Note that the _email_ and _name_ fields now contains both the change made in {sg
 .Request
 [{snippet-header}]
 ----
-curl --location -g --request DELETE 'http://localhost:4985/traveldb/hotel_88801?rev=3-cc2e758ef63b0daf5b01b2baf98c72b6' // <.>
+curl --location -g --request DELETE 'http://localhost:4984/traveldb/hotel_88801?rev=3-cc2e758ef63b0daf5b01b2baf98c72b6' // <.>
 ----
 <.> Note that we provide the revision ID of the latest revision (3), as returned in the response to the last GET request.
 


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-11517

This is a fix for the above ticket. Description as follows: 
"Create a New Document"

Uses the wrong port. The Admin API is not the API used for Sync Server users call so should target http://localhost:4984/ not http://localhost:4985/