### PR TITLE
DOC-11841: add 7.2 to matrix

### DIFF
--- a/modules/ROOT/pages/_partials/sgw-svr-compatibility.adoc
+++ b/modules/ROOT/pages/_partials/sgw-svr-compatibility.adoc
@@ -57,16 +57,17 @@ include::partial$block-caveats.adoc[tags="cbs6.0ke-xattrs"]
 
 .Sync Gateway/Couchbase Server
 Compatibility Matrix
-[cols="^1,3,^1,^1,^1,^1,^1"]
+[cols="^1,3,^1,^1,^1,^1,^1,^1"]
 |===
 
 2+^.>|Sync Gateway ↓
-5+^|Couchbase Server →
+6+^|Couchbase Server →
 ^.>| Version ^.>| Scenario
-^.>| 5.0  *{fn3-0}* ^.>| 5.1  *{fnref3-0}* ^.>| 5.5-6.0|6.5-7.0|7.1
+^.>| 5.0  *{fn3-0}* ^.>| 5.1  *{fnref3-0}* ^.>| 5.5-6.0|6.5-7.0|7.1|7.2
 
 | 1.4 *{fn-eos-sgw}*
 | `feed_type: "DCP"`
+| image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
@@ -80,9 +81,11 @@ Compatibility Matrix
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
 
 | 1.5 *{fnref-eol-sgw}*
 | `shared_bucket_access: true`
+| image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
@@ -96,9 +99,11 @@ Compatibility Matrix
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
 
 | 2.0
 | `shared_bucket_access: true`
+| image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
@@ -113,9 +118,11 @@ Compatibility Matrix
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
 
 | 2.1
 | `shared_bucket_access: true`
+| image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
@@ -129,10 +136,12 @@ Compatibility Matrix
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
 
 | 2.5-2.8
 | `shared_bucket_access: false` +
 `use_views: true`
+| image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
@@ -146,11 +155,13 @@ Compatibility Matrix
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
+| image:ROOT:yes.png[]
 
 | 2.5-2.8
 |`use_views: false`
 | image:ROOT:no.png[]
 | image:ROOT:no.png[]
+| image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
@@ -160,6 +171,7 @@ Compatibility Matrix
 | image:ROOT:no.png[]
 | image:ROOT:no.png[]
 | image:ROOT:no.png[]
+| image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 | image:ROOT:yes.png[]
 // |1.3{fnref-eos-sgw}


### PR DESCRIPTION
This is a fix for: https://issues.couchbase.com/browse/DOC-11841. Just updating for 3.0.
Sync gateway compatibility matrix is missing Couchbase server 7.2 compatibility info. Please update the table to reflect Couchbase server 7.2 compatibility with Sync gateway version 3.0 and 3.1.