### PR TITLE
[BACKPORT] DOC-10808: make the performance impact more prominent.

### DIFF
--- a/modules/ROOT/pages/_partials/sync-api/sync-function-api-access.adoc
+++ b/modules/ROOT/pages/_partials/sync-api/sync-function-api-access.adoc
@@ -26,7 +26,6 @@ NOTE: As a convenience, the resolved value of either argument may be `null` or `
 == Context
 
 You can invoke this function multiple times from within your Sync Function.
-But note that, invoking it multiple times to grant the same user access to the same channel, will result in negative performance implications.
 
 TIP: Prefix the `username` argument value with `role:` to apply this function to a role rather than a user.
 This grants access to the specified channel(s) for all users assigned that role.
@@ -34,7 +33,6 @@ This grants access to the specified channel(s) for all users assigned that role.
 The effects of all access calls by all active documents are effectively combined in a union, so if _any_ document grants a user access to a channel, that user has access to the channel.
 
 You can use the _all channels_ wildcard ('***') to grant the user access to all documents in all channels.
-
 
 == Use
 
@@ -58,5 +56,6 @@ access ("snej", null);
 <.> The null arguments mean these are treated as no-ops
 ====
 
+WARNING: Invoking the Access function multiple times to grant the same user access to the same channel, will result in negative performance implications such as abnormally large fetches or request timeouts.
 
 // END

--- a/modules/ROOT/pages/_partials/sync-api/sync-function-api-access.adoc
+++ b/modules/ROOT/pages/_partials/sync-api/sync-function-api-access.adoc
@@ -56,6 +56,6 @@ access ("snej", null);
 <.> The null arguments mean these are treated as no-ops
 ====
 
-WARNING: Invoking the 'access()' function multiple times to grant the same user access to the same channel, will result in negative performance implications such as abnormally large fetches or request timeouts.
+WARNING: Invoking the 'access()' function multiple times to grant the same user access to the same channel will result in negative performance implications, such as large fetches or request timeouts.
 
 // END

--- a/modules/ROOT/pages/_partials/sync-api/sync-function-api-access.adoc
+++ b/modules/ROOT/pages/_partials/sync-api/sync-function-api-access.adoc
@@ -56,6 +56,6 @@ access ("snej", null);
 <.> The null arguments mean these are treated as no-ops
 ====
 
-WARNING: Invoking the 'access()' function multiple times to grant the same user access to the same channel will result in negative performance implications, such as large fetches or request timeouts.
+WARNING: If you invoke the `access()` function multiple times to grant the same user access to the same channel, you could see negative performance effects, such as large fetches or request timeouts.
 
 // END

--- a/modules/ROOT/pages/_partials/sync-api/sync-function-api-access.adoc
+++ b/modules/ROOT/pages/_partials/sync-api/sync-function-api-access.adoc
@@ -56,6 +56,6 @@ access ("snej", null);
 <.> The null arguments mean these are treated as no-ops
 ====
 
-WARNING: Invoking the Access function multiple times to grant the same user access to the same channel, will result in negative performance implications such as abnormally large fetches or request timeouts.
+WARNING: Invoking the 'access()' function multiple times to grant the same user access to the same channel, will result in negative performance implications such as abnormally large fetches or request timeouts.
 
 // END

--- a/modules/ROOT/pages/sync-function-api.adoc
+++ b/modules/ROOT/pages/sync-function-api.adoc
@@ -26,7 +26,7 @@ ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:
 :page-partial:
-:description: pass:q[Use Sync Functionss to implement effective data routing and access control in the cloud-to-edge synchronization of enterprise data.]
+:description: pass:q[Use Sync Functions to implement effective data routing and access control in the cloud-to-edge synchronization of enterprise data.]
 :idprefix:
 :idseparator: -
 


### PR DESCRIPTION
This is a fix for the ticket: https://issues.couchbase.com/browse/DOC-10808

Ticket Description: The warning about the negative performance impact of repeated access() calls from the sync function should be made more prominent. This could be moved to the top of the page, be placed in a warning box to emphasise, etc.

Currently the only warning is under the Context subheading.

"But note that, invoking it multiple times to grant the same user access to the same channel, will result in negative performance implications."

Which is quite easy to overlook.

I have moved the quote to the bottom of the description, changed it to warning to increase the prominence and made the warning more specific in relation to the specific performance issues it causes.