### PR TITLE
CBG-3865: Added 3.1.5 release notes

### DIFF
--- a/modules/ROOT/pages/_partials/release_notes/sync-gateway-3-1-5-release-note.adoc
+++ b/modules/ROOT/pages/_partials/release_notes/sync-gateway-3-1-5-release-note.adoc
@@ -7,9 +7,9 @@ NOTE: For an overview of the latest features offered in Sync Gateway 3.1, see xr
 [WARNING]
 --
 
-We have discovered a critical issue impacting a few customers that utilize OIDC. 
+We have discovered a critical issue in release 3.1.4 impacting a few customers that utilize OIDC. 
 This issue could lead to users losing access to channels, consequently resulting in document revocations.
-We suggest all users revert their Sync Gateway to version 3.1.3 as a precautionary step or promptly upgrade to version 3.1.5.
+We suggest all users revert promptly upgrade to version 3.1.5.
 
 --
 

--- a/modules/ROOT/pages/_partials/release_notes/sync-gateway-3-1-5-release-note.adoc
+++ b/modules/ROOT/pages/_partials/release_notes/sync-gateway-3-1-5-release-note.adoc
@@ -1,0 +1,64 @@
+== 3.1.5 -- April 2024
+
+Version 3.1.5 of Sync Gateway delivers the following features and enhancements:
+
+NOTE: For an overview of the latest features offered in Sync Gateway 3.1, see xref:whatsnew.adoc[New in 3.1].
+
+[WARNING]
+--
+
+We have discovered a critical issue impacting a few customers that utilize OIDC. 
+This issue could lead to users losing access to channels, consequently resulting in document revocations.
+We suggest all users revert their Sync Gateway to version 3.1.3 as a precautionary step or promptly upgrade to version 3.1.5.
+
+--
+
+[#maint-3-1-5]
+
+=== Fixed Issues
+
+* https://issues.couchbase.com/browse/CBG-3885[CBG-3885 - Fixed OIDC-auth causes admin_channels/admin_roles loss]
+
+* https://issues.couchbase.com/browse/CBG-3887[CBG-3887 - Fixed sgcollect_info fails to upload to s3]
+
+* https://issues.couchbase.com/browse/CBG-3029[CBG-3029 - Fixed sg_collect fails to get SGW config]
+
+* https://issues.couchbase.com/browse/CBG-3611[CBG-3611 - Fixed PUT to _user/<username> does not override omitted fields]
+
+* https://issues.couchbase.com/browse/CBG-3699[CBG-3699 - Fixed error from handleChangesResponse not handled correctly]
+
+* https://issues.couchbase.com/browse/CBG-3723[CBG-3723 - Fixed TCP_NODELAY does not work for TLS connections]
+
+* https://issues.couchbase.com/browse/CBG-3725[CBG-3725 - Fixed import DCP rollback unsuccessful in data migration cases]
+
+* https://issues.couchbase.com/browse/CBG-3744[CBG-3744 - Fixed fetchAndLoadDatabase NewDatabaseContext race]
+
+* https://issues.couchbase.com/browse/CBG-3760[CBG-3760 - Fixed sgcollect_info not collecting trace logging]
+
+* https://issues.couchbase.com/browse/CBG-3761[CBG-3761 - Fixed user API Ignore read-only fields if values unchanged]
+
+* https://issues.couchbase.com/browse/CBG-3774[CBG-3774 - Fixed incorrect log key used for log message inside DocChanged function]
+
+* https://issues.couchbase.com/browse/CBG-3777[CBG-3777 - Fixed kv_pool_size on import feed can be non zero]
+
+* https://issues.couchbase.com/browse/CBG-3793[CBG-3793 - Perform allow_dbconfig_env_vars check in getAuthScopeHandleCreateDB]
+
+* https://issues.couchbase.com/browse/CBG-3812[CBG-3812 - Fixed sg_collect fails to get SGW config]
+
+=== Enhancements
+
+* https://issues.couchbase.com/browse/CBG-3682[CBG-3682 - sgcollect can upload zips in excess of 2GB]
+
+* https://issues.couchbase.com/browse/CBG-3749[CBG-3749 - Better logging around config registry operations]
+
+* https://issues.couchbase.com/browse/CBG-3762[CBG-3762 -  BLIP context ID now included in _blipsync response]
+
+* https://issues.couchbase.com/browse/CBG-3776[CBG-3776 - There is now a configurable revs parallelism limit]
+
+=== Known Issues
+
+* https://issues.couchbase.com/browse/CBG-3614[CBG-3614 - DCP node list/alternate adddresses do not refresh after cluster topology change]
+
+=== Deprecations
+
+None for this release.

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -42,6 +42,8 @@ The migration to 3.x configuration is a ONE WAY process -- see: {upgrading--xref
 :param-release-tag: -1
 
 [#maint-latest]
+include::partial$release_notes/sync-gateway-3-1-5-release-note.adoc[]
+
 include::partial$release_notes/sync-gateway-3-1-3-release-note.adoc[]
 
 include::partial$release_notes/sync-gateway-3-1-2-release-note.adoc[]


### PR DESCRIPTION
PR for the ticket: https://issues.couchbase.com/browse/CBG-3865

Added 3.1.5 release notes and a warning to revert 3.1.4 back to 3.1.3 or upgrade to 3.1.5.