### PR TITLE
Driveby: fix page edition and release (3.0)

### DIFF
--- a/modules/ROOT/pages/database-management.adoc
+++ b/modules/ROOT/pages/database-management.adoc
@@ -1,6 +1,5 @@
 = Database Management
-:page-edition: {release}
-:page-status: {prerelease}
+:page-status: Prerelease
 :page-toclevels: 2@
 :page-pagination: next
 :page-role:


### PR DESCRIPTION
I noticed this page, which give slightly odd results in Search for both 3.1 and 3.0