### PR TITLE
DOC-11833: Field level encryption no longer an issue for SG property names

### DIFF
--- a/modules/ROOT/pages/data-modeling.adoc
+++ b/modules/ROOT/pages/data-modeling.adoc
@@ -20,11 +20,10 @@ include::partial$_set_page_context.adoc[]
 include::partial$_show_page_header_block.adoc[]
 // END -- Page Heading
 
-
 == Introduction
+
 The guidance and constraints documented here relate to the design of data buckets and documents that you require, or may potentially require, to replicate using sync gateway functionality.
 They do not necessarily align with constraints on the local storage and use of such documents.
-
 
 == Property Naming
 
@@ -55,10 +54,16 @@ This rule applies to writes performed through:
 When you might encounter the error::
 You are especially likely to encounter the error in the following deployment situations:
 
-* In Mobile-to-Web Data Sync with Field-level Encryption enabled, because the rule conflicts with the default {xref-sdk-java-encryption}
 * In Mobile-to-Web Data Sync with {xref-sdk-nodejs-pg-start} and http://ottomanjs.com/[Ottoman.js] (the Node.js ODM for Couchbase), where the rule conflicts with the `+_type+` property that is automatically added by _Ottoman.js_.
 +
 A suggested workaround in this scenario is to fork the _Ottoman.js_ library, perform a search-replace for the `+_type+` property and replace it without a leading underscore.
+
+[NOTE] 
+====
+For versions 2.x of Sync Gateway, you can encounter the following error:
+
+* In Mobile-to-Web Data Sync with Field-level Encryption enabled, because the rule conflicts with the default {xref-sdk-java-encryption}
+====
 
 How to avoid the error::
 You should change any top-level user properties that have a key with a leading underscore , by either:
@@ -66,13 +71,11 @@ You should change any top-level user properties that have a key with a leading u
 * Renaming them to remove the underscore, or,
 * Wrapping them inside another object with a key that doesn't have a leading underscore.
 
-
 == Document Structure
 
 Couchbase's unit of data is a document, this is the NOSQL equivalent of a row or record.
 
 Documents are stored as a key-value pair, which comprises a unique and immutable key, the _Id_, and a value representing the users' data (a JSON-object or binary blob).
-
 
 === Key
 
@@ -96,7 +99,6 @@ As a result documents can represent highly-complex data structures in a readily 
 +
 These attachments provide a means to store large media files or any other non-textual data.
 Couchbase Lite supports attachments of unlimited size, although the Sync Gateway currently imposes a 20MB limit for attachments synced to it.
-
 
 == Document Attributes
 Each _Document_ has the following attributes:


### PR DESCRIPTION
Fix to a ticket raised by support: https://issues.couchbase.com/browse/DOC-11833

I've moved the out of date information to a NOTE block mentioning it applies to versions 2.x
Also some tidying up of the file to remove white space.

The following is noted when discussing potential issues with field names with Sync Gateway:

In Mobile-to-Web Data Sync with Field-level Encryption enabled, because the rule conflicts with the default field encryption format

However, this only applies to SDK 2 which made use of an underscored _crypt key prefix. In SDK3 this was changed to encrypted$ to avoid conflicting with Sync Gateway.

While this can be changed to the legacy, saying outright that field level encryption will cause issues with Sync Gateway is no longer accurate.

