### PR TITLE
Doc 11541 fix install instructions

### DIFF
--- a/modules/ROOT/pages/_partials/_attributes-local.adoc
+++ b/modules/ROOT/pages/_partials/_attributes-local.adoc
@@ -63,12 +63,12 @@
 // SYNC GATEWAY VERSIONING
 ifndef::major[:major: 2]
 ifndef::minor[:minor: 8]
-ifndef::patch[:patch: 3]
+ifndef::patch[:patch: 4]
 // ifndef::version[:version: {major}.{minor}]
 // Sever shared connection for these attributes
 :version: {major}.{minor}
 :version-full: {major}.{minor}.0
-:version-maint: {major}.{minor}.{patch}
+:version-maint: {major}.{minor}.{maintenance}
 :version-date: October 2021
 :version-maint-date: {version-date}
 // END SYNC GATEWAY VERSIONING

--- a/modules/ROOT/pages/get-started-install.adoc
+++ b/modules/ROOT/pages/get-started-install.adoc
@@ -9,7 +9,7 @@ include::partial$_std-hdr-sgw.adoc[]
 // BEGIN -- Page Attributes
 :xref-pfx: {xref-pfx-sgw}:
 
-:downloads--url: {url-downloads}#couchbase-mobile[Couchbase downloads page]
+:downloads--url: https://www.couchbase.com/downloads/?family=sync-gateway[downloads page]
 :sg_download_link: {url-package-downloads}/{version-maint}/
 :sg_package_name: couchbase-sync-gateway-community_{version-maint}_x86_64
 :sg_package_name_ee: couchbase-sync-gateway-enterprise_{version-maint}_x86_64
@@ -93,28 +93,7 @@ In this Section::
 
 
 === Download
-Download the required edition of Sync Gateway from the {downloads--url} or alternatively use `wget` to copy the install package -- see: <<ex-linux-wget>>
-
-
-[#ex-linux-wget]
-.Using wget
-====
-[source, bash, subs="attributes+,macros+"]
-----
-wget {sg_download_link}<package-name>.<package-suffix> // <.> <.>
-----
-
-<.> Where <package-name> is one of:
-
-* Enterprise Edition -- `{sg_package_name_ee}`
-* Community Edition -- `{sg_package_name}`
-
-<.> Where <package-suffix> is one of:
-
-* Ubuntu -- `deb`
-* Debian -- `deb`
-* Red Hat / CentOS -- `rpm`
-====
+Download the required edition of Sync Gateway from the {downloads--url}.
 
 
 [#lbl-linux-install]
@@ -264,16 +243,16 @@ You will need to find and replace the path in following line with your required 
 
 .One way to do this is to use `systemctl`
 
-. Ensure the new file path includes a useable Sync Gateway configuration file
-. Stop the service
-. Copy the existing `sync_gateway.service` file to a safe location as a back-up
+. Ensure the new file path includes a useable Sync Gateway configuration file.
+. Stop the service.
+. Copy the existing `sync_gateway.service` file to a safe location as a back-up.
 . Use `sudo systemctl --full edit sync_gateway` to edit the service +
 This will create a temporary file in `/etc/systemd/system/sync_gateway.d` containing your changes.
 This file is picked-up and applied when the daemon reloads.
 Note, `systemctl edit` automatically reloads the edited unit.
 . Replace the path in `Environment="CONFIG=/home/sync_gateway/sync_gateway.json"` with your required path
 . Save the changes +
-When the daemon reload completes, Sync Gateway will restart using the required configuration file
+When the daemon reload completes, Sync Gateway will restart using the required configuration file.
 
 
 == Install for Windows
@@ -469,32 +448,16 @@ In this Section::
 
 
 === Download
-Download the required edition of Sync Gateway from the {downloads--url} or alternatively use `wget` to copy the install package -- see: <<ex-macos-wget>>
-
-
-[#ex-macos-wget]
-.Using wget
-====
-[source,bash,subs="+attributes,+macros"]
-----
-wget {sg_download_link}<package-name>.tar.gz // <.>
-----
-
-<.> Where <package-name> is one of:
-
-* Enterprise Edition -- `{sg_package_name_ee}`
-* Community Edition -- `{sg_package_name}`
-
-====
+Download the required edition of Sync Gateway from the {downloads--url}.
 
 [#lbl-macos-install]
 === Install
-. Unpack the tar.gz installer to the */opt* directory.
+. Unpack the .zip file to the */opt* directory.
 +
 --
 [{snippet-header}]
 ----
-sudo tar -zxvf {sg_package_name_ee}.tar.gz --directory /opt
+sudo unzip -d /opt {sg_package_name_ee}.zip
 ----
 --
 


### PR DESCRIPTION
This is a fix for the following ticket: https://issues.couchbase.com/browse/DOC-11541
--------------------------------
It shall apply to all current release versions: 2.8, 3.0, and 3.1.
Summary: We should not be instructing users to download files within the install docs on Sync Gateway and should instead direct them to the relevant downloads section on the website.
There are also fixes on the MacOS side as the files are now .zip and not .tar.gz files, the corresponding bash script has also been altered accordingly.
There are also some flyby fixes to an out of date patch attribute and slowly moving away from patch ready for a cleanup at some point in the future.