### PR TITLE
[BACKPORT] DOC-11541: Fix install instructions

### DIFF
--- a/modules/ROOT/pages/get-started-install.adoc
+++ b/modules/ROOT/pages/get-started-install.adoc
@@ -105,7 +105,7 @@ In this Section::
 
 === Download
 
-Download the required edition of Sync Gateway from the {downloads-mobile--xref} page.
+Download the required edition of Sync Gateway from the {downloads--url}.
 
 [#lbl-linux-install]
 === Install
@@ -267,7 +267,7 @@ In this Section::
 
 
 === Download
-Download the required edition of Sync Gateway from the {downloads-mobile--xref} page.
+Download the required edition of Sync Gateway from the {downloads--url}.
 
 
 [#lbl-windows-install]
@@ -449,7 +449,7 @@ In this Section::
 
 
 === Download
-Download the required edition of Sync Gateway from the {downloads-mobile--xref} page.
+Download the required edition of Sync Gateway from the {downloads--url}.
 
 
 [#lbl-macos-install]

--- a/modules/ROOT/pages/get-started-install.adoc
+++ b/modules/ROOT/pages/get-started-install.adoc
@@ -18,7 +18,7 @@ include::partial$_set_page_context.adoc[]
 :is-verify!:
 // :this-release: 3.0.3
 
-:downloads--url: {downloads-mobile--xref}
+:downloads--url: https://www.couchbase.com/downloads/?family=sync-gateway[downloads page]
 :sg_download_link: pass:q,a[{url-package-downloads}/{version-maintenance}/]
 :sg_package_name: couchbase-sync-gateway-community_{version-maintenance}_x86_64
 :sg_package_name_ee: couchbase-sync-gateway-enterprise_{version-maintenance}_x86_64
@@ -104,29 +104,8 @@ In this Section::
 
 
 === Download
-Download the required edition of Sync Gateway from the {downloads-mobile--xref} page (alternatively use `wget` to copy the install package -- see: <<ex-linux-wget>>).
 
-
-[#ex-linux-wget]
-.Using wget
-====
-[{snippet-header}]
-----
-wget {sg_download_link}<package-name>.<package-suffix> // <.> <.>
-----
-
-<.> Where <package-name> is one of:
-
-* Enterprise Edition -- `{sg_package_name_ee}`
-* Community Edition -- `{sg_package_name}`
-
-<.> Where <package-suffix> is one of:
-
-* Ubuntu -- `deb`
-* Debian -- `deb`
-* Red Hat / CentOS -- `rpm`
-====
-
+Download the required edition of Sync Gateway from the {downloads-mobile--xref} page.
 
 [#lbl-linux-install]
 === Install
@@ -270,16 +249,16 @@ You will need to find and replace the path in following line with your required 
 
 .One way to do this is to use `systemctl`
 
-. Ensure the new file path includes a useable Sync Gateway configuration file
-. Stop the service
-. Copy the existing `sync_gateway.service` file to a safe location as a back-up
-. Use `sudo systemctl --full edit sync_gateway` to edit the service +
+. Ensure the new file path includes a useable Sync Gateway configuration file.
+. Stop the service.
+. Copy the existing `sync_gateway.service` file to a safe location as a back-up.
+. Use `sudo systemctl --full edit sync_gateway` to edit the service. +
 This will create a temporary file in `/etc/systemd/system/sync_gateway.d` containing your changes.
 This file is picked-up and applied when the daemon reloads.
 Note, `systemctl edit` automatically reloads the edited unit.
-. Replace the path in `Environment="CONFIG=/home/sync_gateway/sync_gateway.json"` with your required path
-. Save the changes +
-When the daemon reload completes, Sync Gateway will restart using the required configuration file
+. Replace the path in `Environment="CONFIG=/home/sync_gateway/sync_gateway.json"` with your required path.
+. Save the changes. +
+When the daemon reload completes, Sync Gateway will restart using the required configuration file.
 
 
 == Install for Windows
@@ -470,42 +449,18 @@ In this Section::
 
 
 === Download
-Download the required edition of Sync Gateway from the {downloads-mobile--xref} page (or alternatively use `wget` to copy the install package.
-
-
-.Using wget
-[#ex-macos-wget]
-[{tabs}]
-=====
-
-Enterprise::
-+
---
-[source,bash,subs="attributes+,macros+"]
-----
-wget {sg_package_name_ee}.tar.gz
-----
---
-
-Community::
-+
---
-[source,bash,subs="attributes+,macros+"]
-----
-wget {sg_package_name}.tar.gz
-----
---
-=====
+Download the required edition of Sync Gateway from the {downloads-mobile--xref} page.
 
 
 [#lbl-macos-install]
 === Install
-. Unpack the tar.gz installer to the */opt* directory.
+
+. Unpack the .zip file to the */opt* directory.
 +
 --
 [{snippet-header}]
 ----
-sudo tar -zxvf {sg_package_name_ee}.tar.gz --directory /opt
+sudo unzip -d /opt {sg_package_name_ee}.zip
 ----
 --
 


### PR DESCRIPTION
This is a fix for the following ticket: https://issues.couchbase.com/browse/DOC-11541
--------------------------------
It shall apply to all current release versions: 2.8, 3.0, and 3.1.
Summary: We should not be instructing users to download files within the install docs on Sync Gateway and should instead direct them to the relevant downloads section on the website.
There are also fixes on the MacOS side as the files are now .zip and not .tar.gz files, the corresponding bash script has also been altered accordingly.