### PR TITLE
[DOC-10197/release/3.1]: Bootstrap config hostnames must be of the Data Service Nodes specifically. Added warning note about using a node running the data service.

### DIFF
--- a/modules/ROOT/assets/attachments/bundled-admin.yaml
+++ b/modules/ROOT/assets/attachments/bundled-admin.yaml
@@ -2267,7 +2267,7 @@ paths:
                         type: string
                         default: 10s
                       server:
-                        description: Couchbase Server connection string/URL.
+                        description: Couchbase Server connection string/URL. (The connection must point to a node running the data service)
                         type: string
                       username:
                         description: Username for authenticating to server.

--- a/modules/ROOT/pages/_partials/static_restapi/admin/index.adoc
+++ b/modules/ROOT/pages/_partials/static_restapi/admin/index.adoc
@@ -47802,6 +47802,8 @@ a| *+server+* +
 _required_
 a| Couchbase Server connection string/URL.
 
+IMPORTANT: The connection must point to a node running the data service.
+
 [%hardbreaks]
 ifeval::["null" != "null"]
 *Default:* `null`

--- a/modules/ROOT/pages/command-line-options.adoc
+++ b/modules/ROOT/pages/command-line-options.adoc
@@ -98,7 +98,9 @@ The command-line options that can be used when starting Sync Gateway are outline
 
 | -bootstrap.server
 |
-| Couchbase Server connection string/URL
+a|Couchbase Server connection string/URL
+
+IMPORTANT: The connection must point to a node running the data service.
 
 | -bootstrap.username
 |


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-10197