### PR TITLE
[DOC-10197/release/3.0]: Bootstrap config hostnames must be of the Data Service Nodes specifically. Added warning note about using a node running the data service.

### DIFF
--- a/modules/ROOT/pages/command-line-options.adoc
+++ b/modules/ROOT/pages/command-line-options.adoc
@@ -98,7 +98,9 @@ The command-line options that can be used when starting Sync Gateway are outline
 
 | -bootstrap.server
 |
-| Couchbase Server connection string/URL
+a|Couchbase Server connection string/URL
+
+IMPORTANT: The connection must point to a node running the data service.
 
 | -bootstrap.username
 |


### PR DESCRIPTION
Added note to tell users that they must connect to a node running the data service.