### PR TITLE
DOC-12519: 3.1.11 relnotes doc

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -13,7 +13,7 @@ asciidoc:
     release: '3.1'
     major: 3
     minor: 1
-    maintenance: 8
+    maintenance: 11
     base: 0
     page-toclevels: 2@
     # releasetag:

--- a/modules/ROOT/pages/_partials/release_notes/sync-gateway-3-1-11-release-note.adoc
+++ b/modules/ROOT/pages/_partials/release_notes/sync-gateway-3-1-11-release-note.adoc
@@ -5,9 +5,9 @@ Version 3.1.11 of Sync Gateway delivers the following features and enhancements:
 [#maint-3-1-11]
 === Fixed Issues
 
-* https://issues.couchbase.com/browse/CBG-4221[CBG-4221 - Pending unused sequences shouldn't update high cache sequence]
+* https://jira.issues.couchbase.com/browse/CBG-4221[CBG-4221 - Pending unused sequences shouldn't update high cache sequence]
 
-* https://issues.couchbase.com/browse/CBG-4218[CBG-4218 - Fixed duplicated sequences can cause SGW to be unresponsive]
+* https://jira.issues.couchbase.com/browse/CBG-4218[CBG-4218 - Duplicated sequences can cause SGW to be unresponsive]
 
 
 === Enhancements

--- a/modules/ROOT/pages/_partials/release_notes/sync-gateway-3-1-11-release-note.adoc
+++ b/modules/ROOT/pages/_partials/release_notes/sync-gateway-3-1-11-release-note.adoc
@@ -1,0 +1,25 @@
+== 3.1.11 -- September 2024
+
+Version 3.1.11 of Sync Gateway delivers the following features and enhancements:
+
+[#maint-3-1-11]
+=== Fixed Issues
+
+* https://issues.couchbase.com/browse/CBG-4221[CBG-4221 - Pending unused sequences shouldn't update high cache sequence]
+
+* https://issues.couchbase.com/browse/CBG-4218[CBG-4218 - Fixed duplicated sequences can cause SGW to be unresponsive]
+
+
+=== Enhancements
+
+None for this release.
+
+=== Known Issues
+
+None for this release.
+
+=== Deprecations
+
+None for this release.
+
+NOTE: For an overview of the latest features offered in Sync Gateway 3.1, see xref:whatsnew.adoc[New in 3.1].

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -51,6 +51,8 @@ The migration to 3.x configuration is a ONE WAY process -- see: {upgrading--xref
 :param-release-tag: -1
 
 [#maint-latest]
+include::partial$release_notes/sync-gateway-3-1-11-release-note.adoc[]
+
 include::partial$release_notes/sync-gateway-3-1-8-release-note.adoc[]
 
 include::partial$release_notes/sync-gateway-3-1-6-release-note.adoc[]


### PR DESCRIPTION
Release notes for Sync Gateway 3.1.11.

3.1.9 and 3.1.10 were removed in a previous PR due to a critical bug.