### PR TITLE
[DOC-11816]:Remove references to deprecated certificate fields in SGW bootstrap config.

### DIFF
--- a/modules/ROOT/pages/authentication-certs.adoc
+++ b/modules/ROOT/pages/authentication-certs.adoc
@@ -94,7 +94,7 @@ Whichever way you obtained the certificate, you will now have a private key and 
 Ensure that they're in separate files and in PEM format, and put them in a directory that's readable by the Sync Gateway process.
 The private key is very sensitive (it's not encrypted), so make sure the file isn't readable by unauthorized processes.
 
-Then just add the `"api.https.tls_cert_path` and `api.https.tls_key_path` properties to your Sync Gateway configuration file.
+Then just add the `api.https.tls_cert_path` and `api.https.tls_key_path` properties to your Sync Gateway configuration file.
 
 [source,javascript]
 ----

--- a/modules/ROOT/pages/authentication-certs.adoc
+++ b/modules/ROOT/pages/authentication-certs.adoc
@@ -41,13 +41,13 @@ The advantage of this approach is that NGINX can proxy both HTTP and HTTPS conne
 Sync Gateway also supports serving connections over SSL.
 To enable SSL, you need to add two properties to the config file:
 
-`"SSLCert"`::
+`api.https.tls_cert_path`::
 A path to a PEM-format file containing an X.509 certificate or a certificate chain.
-`"SSLKey"`::
+`api.https.tls_key_path`::
 A path to a PEM-format file containing the certificate's matching private key.
 
 If both properties are present, the server will respond to SSL (and only SSL) over both the public and admin ports.
-If you want to support both HTTP and HTTPS connections you will need to run two separate instances of Sync Gateway.
+If you want to support both HTTP and HTTPS connections, you will need to run two separate instances of Sync Gateway.
 
 == How to Create an SSL Certificate
 
@@ -92,16 +92,16 @@ $ openssl x509 -inform PEM -in cert.pem -outform DER -out cert.cer
 
 Whichever way you obtained the certificate, you will now have a private key and an X.509 certificate.
 Ensure that they're in separate files and in PEM format, and put them in a directory that's readable by the Sync Gateway process.
-The private key is very sensitive (it's not encrypted) so make sure the file isn't readable by unauthorized processes.
+The private key is very sensitive (it's not encrypted), so make sure the file isn't readable by unauthorized processes.
 
-Then just add the `"SSLCert"` and `"SSLKey"` properties to your Sync Gateway configuration file.
+Then just add the `"api.https.tls_cert_path` and `api.https.tls_key_path` properties to your Sync Gateway configuration file.
 
 [source,javascript]
 ----
 {
 
-  "SSLCert": "cert.pem",
-  "SSLKey": "privkey.pem",
+  "api.https.tls_cert_path": "cert.pem",
+  "api.https.tls_key_path": "privkey.pem",
 
 }
 ----


### PR DESCRIPTION
Certificate fields replaced with corrected parameters.
Other minor corrections were made, since I was there anyway.