### PR TITLE
DOC-12304: Typo corrections and adding use case

### DIFF
--- a/modules/ROOT/pages/_partials/sgw-svr-compatibility.adoc
+++ b/modules/ROOT/pages/_partials/sgw-svr-compatibility.adoc
@@ -57,7 +57,7 @@ include::partial$block-caveats.adoc[tags="cbs6.0ke-xattrs"]
 
 .Sync Gateway/Couchbase Server
 Compatibility Matrix
-[cols="^1,3,^1,^1,^1,^1,^1,^1,^1,^1"]
+[cols="^1,3,^1,^1,^1,^1,^1,^1,^1"]
 |===
 
 2+^.>|Sync Gateway ↓

--- a/modules/ROOT/pages/server-compatibility-eventing.adoc
+++ b/modules/ROOT/pages/server-compatibility-eventing.adoc
@@ -49,7 +49,7 @@ Sync Gateway 3.2.0 now supports interoperability with Eventing from Couchbase Se
 You can use Eventing to handle data changes that happen when applications interact and to integrate with other Couchbase services such as Data, Query and Full Text Search.
 
 
-You can now create Eventing functions with read write bindings with the source bucket associated with a Sync Gateway database.
+You can now create Eventing functions with read-write bindings with the source bucket associated with a Sync Gateway database.
 
 You can also use Eventing to generate vector embeddings from document fields, see xref:couchbase-lite:ROOT/cbl-whatsnew.adoc#vector-search[Vector Search] for more details about Vector Search with Couchbase Lite.
 

--- a/modules/ROOT/pages/whatsnew.adoc
+++ b/modules/ROOT/pages/whatsnew.adoc
@@ -28,6 +28,9 @@ This can only happen during a mixed mode of SGW with a 3.2 version and an older 
 * *Eventing Support with Sync Gateway 3.2.0+ and Couchbase Server 7.6.3+*
 
 Sync Gateway 3.2.0 now supports improved interoperability with Eventing from Couchbase Server version 7.6.3+.
+
+
+You can now create Eventing functions with read write bindings with the source bucket associated with a Sync Gateway database.
 You can use Eventing to handle data changes that happen when applications interact and to integrate with other Couchbase services such as Data, Query and Full Text Search.
 
 For more information, see xref:server-compatibility-eventing.adoc[]

--- a/modules/ROOT/pages/whatsnew.adoc
+++ b/modules/ROOT/pages/whatsnew.adoc
@@ -30,7 +30,7 @@ This can only happen during a mixed mode of SGW with a 3.2 version and an older 
 Sync Gateway 3.2.0 now supports improved interoperability with Eventing from Couchbase Server version 7.6.3+.
 
 
-You can now create Eventing functions with read write bindings with the source bucket associated with a Sync Gateway database.
+You can now create Eventing functions with read-write bindings with the source bucket associated with a Sync Gateway database.
 You can use Eventing to handle data changes that happen when applications interact and to integrate with other Couchbase services such as Data, Query and Full Text Search.
 
 For more information, see xref:server-compatibility-eventing.adoc[]


### PR DESCRIPTION
Request from PM to add an extra line from Eventing doc page to what's new for more context.

Fixing a typo in a table causing misalignment of the table.