### PR TITLE
DOC-12532: remove dead warning admonitions

### DIFF
--- a/modules/ROOT/pages/_partials/release_notes/sync-gateway-3-1-5-release-note.adoc
+++ b/modules/ROOT/pages/_partials/release_notes/sync-gateway-3-1-5-release-note.adoc
@@ -2,15 +2,6 @@
 
 Version 3.1.5 of Sync Gateway delivers the following features and enhancements:
 
-[WARNING]
---
-
-We have discovered a critical issue in release 3.1.4 impacting a few customers that utilize OIDC. 
-This issue could lead to users losing access to channels, consequently resulting in document revocations.
-We suggest all users promptly upgrade to version 3.1.5.
-
---
-
 [#maint-3-1-5]
 
 === Fixed Issues

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -33,15 +33,6 @@ include::partial$_show_page_header_block.adoc[]
 
 // END DO NOT REMOVE
 
-[WARNING]
---
-
-We have discovered a critical issue in releases 3.1.9 and 3.1.10 impacting skipped sequence behavior. 
-This issue could lead to the caching feed ending up in an infinite loop.
-We suggest all users promptly roll back to release 3.1.8 and await the 3.1.11 patch.
-
---
-
 .One Way Upgrade
 [CAUTION]
 --


### PR DESCRIPTION
There has now been ample time for customers to migrate to safe/stable versions. We can now remove these admonitions from docs.