### PR TITLE
DOC-12534: Add removed relnotes from previous releases

### DIFF
--- a/modules/ROOT/pages/_partials/release_notes/sync-gateway-3-1-11-release-note.adoc
+++ b/modules/ROOT/pages/_partials/release_notes/sync-gateway-3-1-11-release-note.adoc
@@ -5,14 +5,45 @@ Version 3.1.11 of Sync Gateway delivers the following features and enhancements:
 [#maint-3-1-11]
 === Fixed Issues
 
+* https://issues.couchbase.com/browse/CBG-3953[CBG-3953 - Avoid timeout on creating indexes asynchronously]
+
+* https://issues.couchbase.com/browse/CBG-3966[CBG-3966 - Fixed error where collection appears to be linked to 2 DBs after update]
+
+* https://issues.couchbase.com/browse/CBG-4004[CBG-4004 - Fixed DeleteRole doesnt trigger history calculation for named collections]
+
+* https://issues.couchbase.com/browse/CBG-4016[CBG-4016 - nextSequenceGreaterThan now updates to current _sync:seq before releasing sequences]
+
+* https://issues.couchbase.com/browse/CBG-4022[CBG-4022 - Fixed race condition between config poll and dbconfig update]
+
+* https://issues.couchbase.com/browse/CBG-4029[CBG-4029 - Fixed  Users dynamically computed roles not getting invalidated after a resync]
+
+* https://issues.couchbase.com/browse/CBG-4073[CBG-4073 - Fixed panic in CheckpointHash function for bucket UUID call]
+
+* https://issues.couchbase.com/browse/CBG-4107[CBG-4107 - Fix error behavior in removeCorruptConfigIfExists where the database wasn't unloaded/removed]
+
+* https://issues.couchbase.com/browse/CBG-4127[CBG-4127 - Decouple client request context from lazy-init OIDC discovery sync process]
+
+* https://issues.couchbase.com/browse/CBG-4173[CBG-4173 - Fixed corrupt DB config handling doesn't remove the config when longer present in the bucket]
+
 * https://jira.issues.couchbase.com/browse/CBG-4221[CBG-4221 - Pending unused sequences shouldn't update high cache sequence]
 
 * https://jira.issues.couchbase.com/browse/CBG-4218[CBG-4218 - Duplicated sequences can cause SGW to be unresponsive]
 
-
 === Enhancements
 
-None for this release.
+* https://issues.couchbase.com/browse/CBG-3983[CBG-3983 -  sgcollect_info: Switch to runtime config endpoint to determine logFilePath]
+
+* https://issues.couchbase.com/browse/CBG-4028[CBG-4028 - Failure to perform on-demand import results in not found/noRev]
+
+* https://issues.couchbase.com/browse/CBG-4035[CBG-4035 - Skipped Sequence Optimisations]
+
+* https://issues.couchbase.com/browse/CBG-4036[CBG-4036 - Detect and handle _sync:seq rollback in sequence allocator]
+
+* https://issues.couchbase.com/browse/CBG-4082[CBG-4082 - Lower config mismatch logging to debug]
+
+* https://issues.couchbase.com/browse/CBG-4145[CBG-4145 -  Improvements to the "could not verify JWT" error logging]
+
+* https://issues.couchbase.com/browse/CBG-4162[CBG-4162 -  Log the origin of setting metadata ID when updating a dbconfig]
 
 === Known Issues
 

--- a/modules/ROOT/pages/_partials/release_notes/sync-gateway-3-1-11-release-note.adoc
+++ b/modules/ROOT/pages/_partials/release_notes/sync-gateway-3-1-11-release-note.adoc
@@ -5,25 +5,25 @@ Version 3.1.11 of Sync Gateway delivers the following features and enhancements:
 [#maint-3-1-11]
 === Fixed Issues
 
-* https://issues.couchbase.com/browse/CBG-3953[CBG-3953 - Avoid timeout on creating indexes asynchronously]
+* https://jira.issues.couchbase.com/browse/CBG-3953[CBG-3953 - Avoid timeout on creating indexes asynchronously]
 
-* https://issues.couchbase.com/browse/CBG-3966[CBG-3966 - Fixed error where collection appears to be linked to 2 DBs after update]
+* https://jira.issues.couchbase.com/browse/CBG-3966[CBG-3966 - Fixed error where collection appears to be linked to 2 DBs after update]
 
-* https://issues.couchbase.com/browse/CBG-4004[CBG-4004 - Fixed DeleteRole doesnt trigger history calculation for named collections]
+* https://jira.issues.couchbase.com/browse/CBG-4004[CBG-4004 - Fixed DeleteRole doesnt trigger history calculation for named collections]
 
-* https://issues.couchbase.com/browse/CBG-4016[CBG-4016 - nextSequenceGreaterThan now updates to current _sync:seq before releasing sequences]
+* https://jira.issues.couchbase.com/browse/CBG-4016[CBG-4016 - nextSequenceGreaterThan now updates to current _sync:seq before releasing sequences]
 
-* https://issues.couchbase.com/browse/CBG-4022[CBG-4022 - Fixed race condition between config poll and dbconfig update]
+* https://jira.issues.couchbase.com/browse/CBG-4022[CBG-4022 - Fixed race condition between config poll and dbconfig update]
 
-* https://issues.couchbase.com/browse/CBG-4029[CBG-4029 - Fixed  Users dynamically computed roles not getting invalidated after a resync]
+* https://jira.issues.couchbase.com/browse/CBG-4029[CBG-4029 - Fixed  Users dynamically computed roles not getting invalidated after a resync]
 
-* https://issues.couchbase.com/browse/CBG-4073[CBG-4073 - Fixed panic in CheckpointHash function for bucket UUID call]
+* https://jira.issues.couchbase.com/browse/CBG-4073[CBG-4073 - Fixed panic in CheckpointHash function for bucket UUID call]
 
-* https://issues.couchbase.com/browse/CBG-4107[CBG-4107 - Fix error behavior in removeCorruptConfigIfExists where the database wasn't unloaded/removed]
+* https://jira.issues.couchbase.com/browse/CBG-4107[CBG-4107 - Fix error behavior in removeCorruptConfigIfExists where the database wasn't unloaded/removed]
 
-* https://issues.couchbase.com/browse/CBG-4127[CBG-4127 - Decouple client request context from lazy-init OIDC discovery sync process]
+* https://jira.issues.couchbase.com/browse/CBG-4127[CBG-4127 - Decouple client request context from lazy-init OIDC discovery sync process]
 
-* https://issues.couchbase.com/browse/CBG-4173[CBG-4173 - Fixed corrupt DB config handling doesn't remove the config when longer present in the bucket]
+* https://jira.issues.couchbase.com/browse/CBG-4173[CBG-4173 - Fixed corrupt DB config handling doesn't remove the config when longer present in the bucket]
 
 * https://jira.issues.couchbase.com/browse/CBG-4221[CBG-4221 - Pending unused sequences shouldn't update high cache sequence]
 
@@ -31,19 +31,19 @@ Version 3.1.11 of Sync Gateway delivers the following features and enhancements:
 
 === Enhancements
 
-* https://issues.couchbase.com/browse/CBG-3983[CBG-3983 -  sgcollect_info: Switch to runtime config endpoint to determine logFilePath]
+* https://jira.issues.couchbase.com/browse/CBG-3983[CBG-3983 -  sgcollect_info: Switch to runtime config endpoint to determine logFilePath]
 
-* https://issues.couchbase.com/browse/CBG-4028[CBG-4028 - Failure to perform on-demand import results in not found/noRev]
+* https://jira.issues.couchbase.com/browse/CBG-4028[CBG-4028 - Failure to perform on-demand import results in not found/noRev]
 
-* https://issues.couchbase.com/browse/CBG-4035[CBG-4035 - Skipped Sequence Optimisations]
+* https://jira.issues.couchbase.com/browse/CBG-4035[CBG-4035 - Skipped Sequence Optimisations]
 
-* https://issues.couchbase.com/browse/CBG-4036[CBG-4036 - Detect and handle _sync:seq rollback in sequence allocator]
+* https://jira.issues.couchbase.com/browse/CBG-4036[CBG-4036 - Detect and handle _sync:seq rollback in sequence allocator]
 
-* https://issues.couchbase.com/browse/CBG-4082[CBG-4082 - Lower config mismatch logging to debug]
+* https://jira.issues.couchbase.com/browse/CBG-4082[CBG-4082 - Lower config mismatch logging to debug]
 
-* https://issues.couchbase.com/browse/CBG-4145[CBG-4145 -  Improvements to the "could not verify JWT" error logging]
+* https://jira.issues.couchbase.com/browse/CBG-4145[CBG-4145 -  Improvements to the "could not verify JWT" error logging]
 
-* https://issues.couchbase.com/browse/CBG-4162[CBG-4162 -  Log the origin of setting metadata ID when updating a dbconfig]
+* https://jira.issues.couchbase.com/browse/CBG-4162[CBG-4162 -  Log the origin of setting metadata ID when updating a dbconfig]
 
 === Known Issues
 


### PR DESCRIPTION
Adding missing tickets to the 3.1.11 release notes.

Tickets are derived from removed 3.1.9 and 3.1.10 release notes as these tickets were also included in the 3.1.11 release.