### PR TITLE
DOC-12547: Correct date to September

### DIFF
--- a/modules/ROOT/pages/_partials/release_notes/sync-gateway-3-2-0-release-note.adoc
+++ b/modules/ROOT/pages/_partials/release_notes/sync-gateway-3-2-0-release-note.adoc
@@ -1,4 +1,4 @@
-== 3.2.0 -- August 2024
+== 3.2.0 -- September 2024
 
 [WARNING]
 --


### PR DESCRIPTION
3.2 release was incorrectly labelled as August when it should be September.