### PR TITLE
DOC-12555: Removed doc for read-write functionality until 7.6.4

### DIFF
--- a/modules/ROOT/pages/server-compatibility-eventing.adoc
+++ b/modules/ROOT/pages/server-compatibility-eventing.adoc
@@ -48,8 +48,8 @@ This can only happen during a mixed mode of SGW with a 3.2 version and an older 
 Sync Gateway 3.2.0 now supports interoperability with Eventing from Couchbase Server version 7.6.3+.
 You can use Eventing to handle data changes that happen when applications interact and to integrate with other Couchbase services such as Data, Query and Full Text Search.
 
-
-You can now create Eventing functions with read-write bindings with the source bucket associated with a Sync Gateway database.
+// Reinstate when Server 7.6.4 is available.
+// You can now create Eventing functions with read-write bindings with the source bucket associated with a Sync Gateway database.
 
 You can also use Eventing to generate vector embeddings from document fields, see xref:couchbase-lite:ROOT/cbl-whatsnew.adoc#vector-search[Vector Search] for more details about Vector Search with Couchbase Lite.
 

--- a/modules/ROOT/pages/whatsnew.adoc
+++ b/modules/ROOT/pages/whatsnew.adoc
@@ -29,8 +29,8 @@ This can only happen during a mixed mode of SGW with a 3.2 version and an older 
 
 Sync Gateway 3.2.0 now supports improved interoperability with Eventing from Couchbase Server version 7.6.3+.
 
-
-You can now create Eventing functions with read-write bindings with the source bucket associated with a Sync Gateway database.
+// Reinstate when Server 7.6.4 is available.
+// You can now create Eventing functions with read-write bindings with the source bucket associated with a Sync Gateway database.
 You can use Eventing to handle data changes that happen when applications interact and to integrate with other Couchbase services such as Data, Query and Full Text Search.
 
 For more information, see xref:server-compatibility-eventing.adoc[]


### PR DESCRIPTION
This is a PR for ticket: https://jira.issues.couchbase.com/browse/DOC-12555

A bug was found related to eventing functions with read-write bindings so this has been commented out of the docs to be restored in Server 7.6.4 when it is fixed.