### PR TITLE
DOC-12595: Add missing config value

### DIFF
--- a/modules/ROOT/assets/attachments/configuration-properties-legacy.yaml
+++ b/modules/ROOT/assets/attachments/configuration-properties-legacy.yaml
@@ -1727,5 +1727,6 @@ properties:
       - "tlsv1"
       - "tlsv1.1"
       - "tlsv1.2"
+      - "tlsv1.3"
     type: string
     default: 'tlsv1'

--- a/modules/ROOT/assets/attachments/configuration-properties-legacy.yaml
+++ b/modules/ROOT/assets/attachments/configuration-properties-legacy.yaml
@@ -1727,6 +1727,6 @@ properties:
       - "tlsv1"
       - "tlsv1.1"
       - "tlsv1.2"
-      - "tlsv1.3"
+      - "tlsv1.2"
     type: string
     default: 'tlsv1'

--- a/modules/ROOT/assets/attachments/configuration-properties-legacy.yaml
+++ b/modules/ROOT/assets/attachments/configuration-properties-legacy.yaml
@@ -1729,4 +1729,4 @@ properties:
       - "tlsv1.2"
       - "tlsv1.2"
     type: string
-    default: 'tlsv1'
+    default: 'tlsv1.2'


### PR DESCRIPTION
Quick one liner for a customer found issue. Adding missing TLS version to tls_minimum version on the legacy config.

Ticket: https://jira.issues.couchbase.com/browse/DOC-12595

Preview showing successful change:
https://preview.docs-test.couchbase.com/legconfig/sync-gateway/current/configuration-properties-legacy.html#tls_minimum_version
