### PR TITLE
DOC-12617: Tidy formatting

### DIFF
--- a/modules/ROOT/pages/_partials/concepts/access-control-model.adoc
+++ b/modules/ROOT/pages/_partials/concepts/access-control-model.adoc
@@ -67,7 +67,7 @@ To override this, use a custom sync function or a Specified Default Sync Functio
 [source, javascript]
 ----
 function (doc, oldDoc, meta) {
-channel(doc.channels);
+   channel(doc.channels);
 
 } 
 ----

--- a/modules/ROOT/pages/_partials/concepts/sync-function.adoc
+++ b/modules/ROOT/pages/_partials/concepts/sync-function.adoc
@@ -57,7 +57,7 @@ NOTE: The Sync Function uses the https://ecma-international.org/wp-content/uploa
 [source, javascript]
 ----
 function (doc, oldDoc, meta) { 
-  channel(CollectionName); 
+   channel(CollectionName); 
 
 }
 ----
@@ -78,7 +78,7 @@ To override this, use a custom sync function or a Specified Default Sync Functio
 [source, javascript]
 ----
 function (doc, oldDoc, meta) {
-  channel(doc.channels);
+   channel(doc.channels);
 
 } 
 ----

--- a/modules/ROOT/pages/_partials/sync-api/sync-function-api-channel.adoc
+++ b/modules/ROOT/pages/_partials/sync-api/sync-function-api-channel.adoc
@@ -70,7 +70,7 @@ To override this, use a custom sync function or a Specified Default Sync Functio
 [source, javascript]
 ----
 function (doc, oldDoc, meta) {
-channel(doc.channels);
+   channel(doc.channels);
 
 } 
 ----

--- a/modules/ROOT/pages/auto-purge-channel-access-revocation.adoc
+++ b/modules/ROOT/pages/auto-purge-channel-access-revocation.adoc
@@ -280,7 +280,7 @@ To override this, use a custom sync function or a Specified Default Sync Functio
 [source, javascript]
 ----
 function (doc, oldDoc, meta) {
-channel(doc.channels);
+   channel(doc.channels);
 
 } 
 ----


### PR DESCRIPTION
PM ask. 

Long term fix is to remove inlined snippets entirely and have common examples files to include from. 

Cosmetic fix for consistent snippets to demonstrate to prospects.