### PR TITLE
DOC-12644: Add server versions to RBAC table

### DIFF
--- a/modules/ROOT/pages/rest-api-access.adoc
+++ b/modules/ROOT/pages/rest-api-access.adoc
@@ -65,7 +65,7 @@ Authenticated users will have access to Admin and-or Metrics API functionality, 
 
 
 [#lbl-rbac-roles]
-== Sync Gateway RBAC Roles
+== Available Server RBAC Roles on Sync Gateway
 
 Couchbase Server makes a number of RBAC roles available for Sync Gateway use.
 Each user's access-level will depend on its allocated role.
@@ -79,7 +79,7 @@ Note that the only role available for community-edition users is the *Full Admin
 
 
 .{sgw-s} role availability by release
-[#tbl-ee-svr-sgw-roles,cols="2,2,^1,^1,^1,^1,^1,^1,^1",options="header"]
+[#tbl-ee-svr-sgw-roles,cols="2,2,^1,^1,^1,^1,^1",options="header"]
 |===
 
 h| Role
@@ -89,8 +89,6 @@ h| 7.2.0
 h| 7.1.0
 h| 7.0.2 DP<<more-on-developer-previews, ^1^>>
 h| 6.1 - 7.0
-h| 5.5 - 6.0
-h| 5.1
 
 
 h| Sync Gateway Architect
@@ -101,8 +99,6 @@ This user cannot read application data.
 | image:yes.png[]
 | image:yes.png[]
 | image:no.png[]
-| image:no.png[]
-| image:no.png[]
 
 h| Sync Gateway Application
 | Can manage Sync Gateway users and roles, and read and write  application data through Sync Gateway.
@@ -111,8 +107,6 @@ h| Sync Gateway Application
 | image:yes.png[]
 | image:yes.png[]
 | image:no.png[]
-| image:no.png[]
-| image:no.png[]
 
 h| Sync Gateway Application Read Only
 | Can read Sync Gateway users and roles, and read application data  through Sync Gateway.
@@ -120,8 +114,6 @@ h| Sync Gateway Application Read Only
 | image:yes.png[]
 | image:yes.png[]
 | image:yes.png[]
-| image:no.png[]
-| image:no.png[]
 | image:no.png[]
 
 h| Sync Gateway Replicator
@@ -132,8 +124,6 @@ This user cannot read application data.
 | image:yes.png[]
 | image:yes.png[]
 | image:no.png[]
-| image:no.png[]
-| image:no.png[]
 
 h| Sync Gateway Dev Ops
 | Can manage Sync Gateway node-level configuration, and access Sync Gateway's /metrics endpoint for Prometheus integration.
@@ -141,8 +131,6 @@ h| Sync Gateway Dev Ops
 | image:yes.png[]
 | image:yes.png[]
 | image:yes.png[]
-| image:no.png[]
-| image:no.png[]
 | image:no.png[]
 
 h| Sync-Gateway Role
@@ -152,8 +140,6 @@ h| Sync-Gateway Role
 | image:no.png[]
 | image:no.png[]
 | image:yes.png[]
-| image:no.png[]
-| image:no.png[]
 
 h| Application Access
 | Can access DB / bucket scoped operations
@@ -162,8 +148,6 @@ h| Application Access
 | image:no.png[]
 | image:no.png[]
 | image:yes.png[]
-| image:yes.png[]
-| image:no.png[]
 
 h| Bucket Full Access
 | Can access DB / bucket scoped operations
@@ -171,8 +155,6 @@ h| Bucket Full Access
 | image:no.png[]
 | image:no.png[]
 | image:no.png[]
-| image:yes.png[]
-| image:yes.png[]
 | image:yes.png[]
 
 h| Full Admin
@@ -182,10 +164,10 @@ h| Full Admin
 | image:no.png[]
 | image:no.png[]
 | image:yes.png[]
-| image:yes.png[]
-| image:yes.png[]
 
 |===
+
+For more information on older, end-of-life versions, see xref:3.0@sync-gateway:ROOT/rest-api-access.adoc[legacy version role availability].
 
 [#more-on-developer-previews]
 ^1^For more information on Developer Previews, see xref:server:developer-preview:preview-mode.adoc[] 

--- a/modules/ROOT/pages/rest-api-access.adoc
+++ b/modules/ROOT/pages/rest-api-access.adoc
@@ -79,11 +79,13 @@ Note that the only role available for community-edition users is the *Full Admin
 
 
 .{sgw-s} role availability by release
-[#tbl-ee-svr-sgw-roles,cols="2,2,^1,^1,^1,^1,^1",options="header"]
+[#tbl-ee-svr-sgw-roles,cols="2,2,^1,^1,^1,^1,^1,^1,^1",options="header"]
 |===
 
 h| Role
 h| Capability
+h| 7.6.0
+h| 7.2.0
 h| 7.1.0
 h| 7.0.2 DP<<more-on-developer-previews, ^1^>>
 h| 6.1 - 7.0
@@ -96,6 +98,8 @@ h| Sync Gateway Architect
 This user cannot read application data.
 | image:yes.png[]
 | image:yes.png[]
+| image:yes.png[]
+| image:yes.png[]
 | image:no.png[]
 | image:no.png[]
 | image:no.png[]
@@ -104,12 +108,16 @@ h| Sync Gateway Application
 | Can manage Sync Gateway users and roles, and read and write  application data through Sync Gateway.
 | image:yes.png[]
 | image:yes.png[]
+| image:yes.png[]
+| image:yes.png[]
 | image:no.png[]
 | image:no.png[]
 | image:no.png[]
 
 h| Sync Gateway Application Read Only
 | Can read Sync Gateway users and roles, and read application data  through Sync Gateway.
+| image:yes.png[]
+| image:yes.png[]
 | image:yes.png[]
 | image:yes.png[]
 | image:no.png[]
@@ -121,12 +129,16 @@ h| Sync Gateway Replicator
 This user cannot read application data.
 | image:yes.png[]
 | image:yes.png[]
+| image:yes.png[]
+| image:yes.png[]
 | image:no.png[]
 | image:no.png[]
 | image:no.png[]
 
 h| Sync Gateway Dev Ops
 | Can manage Sync Gateway node-level configuration, and access Sync Gateway's /metrics endpoint for Prometheus integration.
+| image:yes.png[]
+| image:yes.png[]
 | image:yes.png[]
 | image:yes.png[]
 | image:no.png[]
@@ -137,12 +149,16 @@ h| Sync-Gateway Role
 | Can access DB / bucket scoped operations
 | image:no.png[]
 | image:no.png[]
+| image:no.png[]
+| image:no.png[]
 | image:yes.png[]
 | image:no.png[]
 | image:no.png[]
 
 h| Application Access
 | Can access DB / bucket scoped operations
+| image:no.png[]
+| image:no.png[]
 | image:no.png[]
 | image:no.png[]
 | image:yes.png[]
@@ -153,12 +169,16 @@ h| Bucket Full Access
 | Can access DB / bucket scoped operations
 | image:no.png[]
 | image:no.png[]
+| image:no.png[]
+| image:no.png[]
 | image:yes.png[]
 | image:yes.png[]
 | image:yes.png[]
 
 h| Full Admin
 | Can access all operations
+| image:no.png[]
+| image:no.png[]
 | image:no.png[]
 | image:no.png[]
 | image:yes.png[]

--- a/modules/ROOT/pages/rest-api-access.adoc
+++ b/modules/ROOT/pages/rest-api-access.adoc
@@ -79,14 +79,12 @@ Note that the only role available for community-edition users is the *Full Admin
 
 
 .{sgw-s} role availability by release
-[#tbl-ee-svr-sgw-roles,cols="2,2,^1,^1,^1,^1,^1",options="header"]
+[#tbl-ee-svr-sgw-roles,cols="2,2,^1,^1,^1",options="header"]
 |===
 
 h| Role
 h| Capability
-h| 7.6.0
-h| 7.2.0
-h| 7.1.0
+h| 7.1.0+
 h| 7.0.2 DP<<more-on-developer-previews, ^1^>>
 h| 6.1 - 7.0
 
@@ -96,22 +94,16 @@ h| Sync Gateway Architect
 This user cannot read application data.
 | image:yes.png[]
 | image:yes.png[]
-| image:yes.png[]
-| image:yes.png[]
 | image:no.png[]
 
 h| Sync Gateway Application
 | Can manage Sync Gateway users and roles, and read and write  application data through Sync Gateway.
 | image:yes.png[]
 | image:yes.png[]
-| image:yes.png[]
-| image:yes.png[]
 | image:no.png[]
 
 h| Sync Gateway Application Read Only
 | Can read Sync Gateway users and roles, and read application data  through Sync Gateway.
-| image:yes.png[]
-| image:yes.png[]
 | image:yes.png[]
 | image:yes.png[]
 | image:no.png[]
@@ -121,14 +113,10 @@ h| Sync Gateway Replicator
 This user cannot read application data.
 | image:yes.png[]
 | image:yes.png[]
-| image:yes.png[]
-| image:yes.png[]
 | image:no.png[]
 
 h| Sync Gateway Dev Ops
 | Can manage Sync Gateway node-level configuration, and access Sync Gateway's /metrics endpoint for Prometheus integration.
-| image:yes.png[]
-| image:yes.png[]
 | image:yes.png[]
 | image:yes.png[]
 | image:no.png[]
@@ -137,14 +125,10 @@ h| Sync-Gateway Role
 | Can access DB / bucket scoped operations
 | image:no.png[]
 | image:no.png[]
-| image:no.png[]
-| image:no.png[]
 | image:yes.png[]
 
 h| Application Access
 | Can access DB / bucket scoped operations
-| image:no.png[]
-| image:no.png[]
 | image:no.png[]
 | image:no.png[]
 | image:yes.png[]
@@ -153,14 +137,10 @@ h| Bucket Full Access
 | Can access DB / bucket scoped operations
 | image:no.png[]
 | image:no.png[]
-| image:no.png[]
-| image:no.png[]
 | image:yes.png[]
 
 h| Full Admin
 | Can access all operations
-| image:no.png[]
-| image:no.png[]
 | image:no.png[]
 | image:no.png[]
 | image:yes.png[]

--- a/modules/ROOT/pages/rest-api-access.adoc
+++ b/modules/ROOT/pages/rest-api-access.adoc
@@ -167,7 +167,7 @@ h| Full Admin
 
 |===
 
-For more information on older, end-of-life versions, see xref:3.0@sync-gateway:ROOT/rest-api-access.adoc[legacy version role availability].
+For more information on older, end-of-life versions, see xref:3.0@rest-api-access.adoc[legacy version role availability].
 
 [#more-on-developer-previews]
 ^1^For more information on Developer Previews, see xref:server:developer-preview:preview-mode.adoc[] 


### PR DESCRIPTION
Addressed bug in ticket: https://couchbasecloud.atlassian.net/browse/DOC-12644

Adding missing server versions to RBAC roles table.
Remove older, EOL versions and point to an older version of the doc if they still want to refer to that table.
Clarify table header - now reads `Available Server RBAC Roles on Sync Gateway`

Preview Credentials: https://couchbasecloud.atlassian.net/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords

Changed Pages
-------------------

- RBAC roles table: https://preview.docs-test.couchbase.com/12644preview/sync-gateway/3.1/rest-api-access.html#lbl-rbac-roles

----------------------

Pages still needing changes/updates
-----------------------

....

-----------------------
