### PR TITLE
[DOC-10376/release/3.0] Add missing space in "properties inDatabase Configuration"

### DIFF
--- a/modules/ROOT/pages/delta-sync.adoc
+++ b/modules/ROOT/pages/delta-sync.adoc
@@ -3,7 +3,7 @@ ifdef::show_edition[:page-edition: {release}] {enterprise}
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:
 :page-content: conceptual
-:description: Use Sync Gateway's delta sync feature for secure, resilient and efficient sync from cloud to edge
+:description: Use Sync Gateway's delta sync feature for secure, resilient, and efficient sync from cloud to edge
 :keywords: sync gateway, replication, sync, synchronization, edge, cloud
 :pageOriginRel: "sg=1.5, Cbs=5.0)_"
 
@@ -37,7 +37,7 @@ Replication does not use Delta Sync when pushing to a pre-2.8 target.
 
 == Configuration
 
-You can enable delta-sync on a per-database basic in your Sync Gateway configuration file using the `delta_sync` properties in{rest-api-admin--xref--database-configuration} -- as shown in <<sample-cfg>>:
+You can enable delta-sync on a per-database basic in your Sync Gateway configuration file using the `delta_sync` properties in xref:rest-api-admin.adoc[Database Configuration] -- as shown in <<sample-cfg>>:
 
 [#sample-cfg]
 .Sample of Database with Delta Sync
@@ -80,7 +80,7 @@ So new deltas can only be generated for read requests arriving within the _rev_m
 Setting `rev_max_age_seconds = 0` will generate deltas opportunistically on pull replications, with no additional storage requirements.
 
 [#addl-storage]
-.Additional storage calulation
+.Additional storage calculation
 ====
 Using:
 


### PR DESCRIPTION
### Description
- Added missing space in the text "properties inDatabase Configuration".
- Corrected a spelling mistake.
-  Inlined complicated link.