### PR TITLE
[DOC-11971]: Document that Sync Gateway does not support partial backup/restore

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -131,6 +131,7 @@
   * xref:server-compatibility-eventing.adoc[Eventing]
   * xref:server-compatibility-transactions.adoc[Transactions]
   * xref:server-compatibility-xdcr.adoc[XDCR]
+  * xref:server-compatibility-backups.adoc[Backup and Restore]
 
 .Product Notes
   * xref:release-notes.adoc[Release Notes]

--- a/modules/ROOT/pages/_partials/_define_page_index.adoc
+++ b/modules/ROOT/pages/_partials/_define_page_index.adoc
@@ -699,15 +699,18 @@ endif::xref--pfx-sgw[]
 :setting-up-dr-cluster--page:  setting-up-dr-cluster.adoc
 :setting-up-dr-cluster--xref: {sgw--xref}{setting-up-dr-cluster--page}[Disaster Recovery]
 
-:server-compatibility-xdcr--page:  server-compatibility-xdcr.adoc
-:server-compatibility-xdcr--xref: {sgw--xref}{server-compatibility-xdcr--page}[Server Compatibility - XDCR]
+:server-compatibility-buckets--page: server-compatibility-buckets.adoc
+:server-compatibility-buckets-xref: {sgw--xref}{server-compatibility-buckets--page}[Server Compatibility - Buckets]
+:server-compatibility-collections--page:  server-compatibility-collections.adoc
+:server-compatibility-collections--xref: {sgw--xref}{server-compatibility-collections--page}[Server Compatibility - Collections]
 :server-compatibility-eventing--page:  server-compatibility-eventing.adoc
 :server-compatibility-eventing--xref: {sgw--xref}{server-compatibility-eventing--page}[Server Compatibility - Eventing]
 :server-compatibility-transactions--page:  server-compatibility-transactions.adoc
 :server-compatibility-transactions--xref: {sgw--xref}{server-compatibility-transactions--page}[Server Compatibility - Transactions]
-:server-compatibility-collections--page:  server-compatibility-collections.adoc
-:server-compatibility-collections--xref: {sgw--xref}{server-compatibility-collections--page}[Server Compatibility - Collections]
-
+:server-compatibility-xdcr--page:  server-compatibility-xdcr.adoc
+:server-compatibility-xdcr--xref: {sgw--xref}{server-compatibility-xdcr--page}[Server Compatibility - XDCR]
+:server-compatibility-backup-and-restore--page: server-compatibility-backups.adoc
+:server-compatibility-backup-and-restore--xref: {sgw--xref}{server-compatibility-backup-and-restore--page}[Server Compatibility - Backup and restore]
 :sgcollect-info--page:  sgcollect-info.adoc
 :sgcollect-info--xref: {sgw--xref}{sgcollect-info--page}[SGCollect Info]
 

--- a/modules/ROOT/pages/_partials/topic-group-compatibility.adoc
+++ b/modules/ROOT/pages/_partials/topic-group-compatibility.adoc
@@ -12,25 +12,28 @@ ifdef::param-title[:this-title: {param-title}]
 
 // Begin -- Define Local Attributes with Required Links and Titles for this topic group
 // Set titles for xrefs
-:title-1: XDCR
-:title-2: Eventing
-:title-3: Transactions
-:title-4: Collections
-// :title-5: Conflict
+:title-1: Buckets
+:title-2: Collections
+:title-3: Eventing
+:title-4: Transactions
+:title-5: XDCR
+:title-6: Backup and restore
 
 // Set the pages for the xrefs to link to (we are using attributes from _define_page_index.adoc here)
-:topic-1: {server-compatibility-xdcr--page}
-:topic-2: {server-compatibility-eventing--page}
-:topic-3: {server-compatibility-transactions--page}
-:topic-4: {server-compatibility-collections--page}
-// :topic-5: {sync-inter-syncgateway-conflict-resolution--page}
+:topic-1: {server-compatibility-buckets--page}
+:topic-2: {server-compatibility-collections--page}
+:topic-3: {server-compatibility-eventing--page}
+:topic-4: {server-compatibility-transactions--page}
+:topic-5: {server-compatibility-xdcr--page}
+:topic-6: {server-compatibility-backup-and-restore--page}
 
 // Set the xrefs up using attribute from _define_page_index.adoc and above attributes
 :topic-1--xref: {sgw--xref}{topic-1}[{title-1}]
 :topic-2--xref: {sgw--xref}{topic-2}[{title-2}]
 :topic-3--xref: {sgw--xref}{topic-3}[{title-3}]
 :topic-4--xref: {sgw--xref}{topic-4}[{title-4}]
-// :topic-5--xref: {sgw--xref}{topic-5}[{title-5}]
+:topic-5--xref: {sgw--xref}{topic-5}[{title-5}]
+:topic-6--xref: {sgw--xref}{topic-6}[{title-6}]
 // End -- Local Attributes
 
 // Begin -- Remove the xref link from current calling page
@@ -39,24 +42,27 @@ ifeval::["{this-page}"=="{topic-1}"]
 endif::[]
 
 ifeval::["{this-page}"=="{topic-2}"]
-:topic-2--xref: {title-2}
+:topic-2--xref: pass:q,a[*{title-2}*]
 endif::[]
 
 ifeval::["{this-page}"=="{topic-3}"]
-:topic-3--xref: {title-3}
+:topic-3--xref: pass:q,a[*{title-3}*]
 endif::[]
 
 ifeval::["{this-page}"=="{topic-4}"]
-:topic-4--xref: {title-4}
+:topic-4--xref: pass:q,a[*{title-4}*]
 endif::[]
 
-// ifeval::["{this-page}"=="{topic-5}"]
-// :topic-5--xref: {title-5}
-// endif::[]
+ifeval::["{this-page}"=="{topic-5}"]
+:topic-5--xref: pass:q,a[*{title-5}*]
+endif::[]
+
+ifeval::["{this-page}"=="{topic-6}"]
+:topic-6--xref: pass:q,a[*{title-6}*]
+endif::[]
 // End -- Remove xref link from current page
 // Begin -- Output Block
-_Related {this-title} topics_:  {topic-1--xref}  |  {topic-2--xref}  |  {topic-3--xref}  |  {topic-4--xref}
-// |  {topic-5--xref}
+_Related {this-title} topics_:  {topic-1--xref}  |  {topic-2--xref}  |  {topic-3--xref}  |  {topic-4--xref} |  {topic-5--xref} | {topic-6--xref}
 // End -- Output Block
 
 // Begin -- Tidy-up
@@ -65,17 +71,19 @@ _Related {this-title} topics_:  {topic-1--xref}  |  {topic-2--xref}  |  {topic-3
 :topic-2!:
 :topic-3!:
 :topic-4!:
-// :topic-5!:
+:topic-5!:
 :title-1!:
 :title-2!:
 :title-3!:
 :title-4!:
-// :title-5!:
+:title-5!:
+:title-6!:
 :topic-1--xref!:
 :topic-2--xref!:
 :topic-3--xref!:
 :topic-4--xref!:
-// :topic-5--xref!:
+:topic-5--xref!:
+:topic-6--xref!:
 // End -- Tidy-up
 
 // END -- inclusion -- content-group-configuration.adoc

--- a/modules/ROOT/pages/server-compatibility-backups.adoc
+++ b/modules/ROOT/pages/server-compatibility-backups.adoc
@@ -1,0 +1,40 @@
+= Backup and Restore -- Server Compatibility
+ifdef::show_edition[:page-edition: {release}]
+ifdef::prerelease[:page-status: {prerelease}]
+:page-role:
+:description: Important details concerning the use of backup and restore in conjunction with Sync Gateway.
+:idprefix:
+:idseparator: -
+
+
+include::partial$_set_page_context.adoc[]
+
+
+// BEGIN -- Page Attributes
+// END -- Page Attributes
+
+
+// BEGIN -- Page Header
+:param-topic-group: compatibility
+:param-related: {compatibility--xref}
+:param-abstract!:
+include::partial$_show_page_header_block.adoc[]
+// END -- Page Header
+
+
+== Backups 
+
+
+[IMPORTANT]
+.Partial backups and restores.
+====
+Sync Gateway does not support partial backups/restores. 
+
+Make sure that you perform full backups 
+if you're planning to use them in conjunction with Sync Gateway
+====
+
+
+// BEGIN -- Page Footer
+include::partial$block-related-content-data.adoc[]
+// END -- Page Footer


### PR DESCRIPTION
### Summary

This Pull Request updates documentation for Sync Gateway by improving coverage of backup and restoration compatibility. It introduces a new section and updates multiple attributes and links for proper navigation and organization in the documents.

Main Changes:

Added a New Document: server-compatibility-backups.adoc covering details about backup and restoration compatibility for Sync Gateway.

Updated Navigation: Added a link to the new "Backup and Restore" section in nav.adoc.
Reorganized Definitions: Introduced attributes and cross-references for "Backup and Restore" in _define_page_index.adoc.

Adjusted Topic Groups: Updated topic-group-compatibility.adoc to include the new "Backup and Restore" category. Improved titles and links alignment for consistency.

Highlighted Key Limitation: Stated that Sync Gateway does not support partial backups/restores, recommending full backups instead.
 
### Checklist

- [ ] Unit tests added/updated
- [x] Documentation updated
- [ ] Code reviewed

### Preview

https://preview.docs-test.couchbase.com/docs-sync-gateway-DOC-11971-Document-that-partial-backup/restore-is-not-supported-by-Sync-Gateway/sync-gateway/current/server-compatibility-backups.html