### PR TITLE
DOC-12350 remove prerelease on page status for data page

### DIFF
--- a/modules/ROOT/pages/database-management.adoc
+++ b/modules/ROOT/pages/database-management.adoc
@@ -1,6 +1,5 @@
 = Database Management
 :page-edition: {release}
-:page-status: {prerelease}
 :page-toclevels: 2@
 :page-pagination: next
 :page-role:


### PR DESCRIPTION
Docs Issue: [DOC-12350](https://jira.issues.couchbase.com/browse/DOC-12350)

PR to remove the prerelease tag on data management page for sync gateway. 

Docs preview: [Remove prerelease](https://preview.docs-test.couchbase.com/docs-sync-gateway-DOC-12350-fix-page-status/)
Credentials: [Preview docs for internal review](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords#Preview-docs-for-internal-review)

[DOC-12350]: https://couchbasecloud.atlassian.net/browse/DOC-12350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ