### PR TITLE
DOC-13103: Non-KV nodes in server bootstrap connstr

### DIFF
--- a/modules/ROOT/pages/configuration-schema-bootstrap.adoc
+++ b/modules/ROOT/pages/configuration-schema-bootstrap.adoc
@@ -32,10 +32,12 @@ See the <<lbl-schema, schema>> below for more details on these properties.
 
 Use the following command to run Sync Gateway with a configuration file:
 
-[source, bashrc]
+[source, bash]
 ----
 sync_gateway sync-gateway-bootstrap.json
 ----
+
+NOTE: For reliable operation, all the nodes listed in the xref:bootstrap-server[`bootstrap.server`] connection string must be data (KV) nodes.
 
 [#lbl-schema]
 == Bootstrap Configuration Schema


### PR DESCRIPTION
Docs issue: [DOC-13103](https://jira.issues.couchbase.com/browse/DOC-13103)

Adds note about non-KV nodes in `bootstrap.server`.

Docs preview: [Bootstrap Configuration › Introduction](https://preview.docs-test.couchbase.com/docs-sync-gateway-DOC-13103/sync-gateway/current/configuration-schema-bootstrap.html#introduction)
Credentials: [Preview docs for internal review](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Preview-docs-for-internal-review)

[DOC-13103]: https://couchbasecloud.atlassian.net/browse/DOC-13103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ