### PR TITLE
[DOC-13253]: Feedback on User Authentication | Couchbase Docs

### DIFF
--- a/modules/ROOT/pages/_partials/_define_component_attributes.adoc
+++ b/modules/ROOT/pages/_partials/_define_component_attributes.adoc
@@ -23,7 +23,7 @@
 :version_caoFull: 2.0.0
 
 // Couchbase Components
-:sgw: pass:q,a[sync{nbsp}gateway]
+:sgw: pass:q,a[Sync{nbsp}Gateway]
 :sgw-s: pass:q,a[Sync{nbsp}gateway]
 :sgw-t: pass:q,a[Sync{nbsp}Gateway]
 :sgw-te: pass:q,a[_{sgw-t}_]


### PR DESCRIPTION
Quck fix to capitalize `Sync Gateway` on the user authentication page.

Preview URL:
https://preview.docs-test.couchbase.com/docs-sync-gateway-DOC-13253-Feedback-on-User-Authentication--Couchbase-Docs/sync-gateway/current/authentication-users.html

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.