### PR TITLE
added winning_rev_option for webhooks

### DIFF
--- a/modules/ROOT/pages/_partials/_define_page_index.adoc
+++ b/modules/ROOT/pages/_partials/_define_page_index.adoc
@@ -494,6 +494,7 @@ endif::xref--pfx-sgw[]
 :configuration-schema-database--xref--eventhandlers-doc-changed-handler: {configuration-schema-database--pfx--eventhandlers-doc-changed}-handler[database.event_handlers.document_changed.handler]
 :configuration-schema-database--xref--eventhandlers-doc-changed-timeout: {configuration-schema-database--pfx--eventhandlers-doc-changed}-timeout[database.event_handlers.document_changed.timeout]
 :configuration-schema-database--xref--eventhandlers-doc-changed-url: {configuration-schema-database--pfx--eventhandlers-doc-changed}-url[database.event_handlers.document_changed.url]
+:configuration-schema-database--xref--eventhandlers-doc-changed-options: {configuration-schema-database--pfx--eventhandlers-doc-changed}-options[database.event_handlers.document_changed.options]
 :configuration-schema-database--xref--eventhandlers-max-processes: {configuration-schema-database--pfx--eventhandlers}-max_processes[database.event_handlers.max_processes]
 :configuration-schema-database--xref--eventhandlers-wait-for-process: {configuration-schema-database--pfx--eventhandlers}-wait_for_process[database.event_handlers.wait_for_process]
 

--- a/modules/ROOT/pages/webhooks.adoc
+++ b/modules/ROOT/pages/webhooks.adoc
@@ -129,13 +129,10 @@ Options::
 --
 Property name: {configuration-schema-database--xref--eventhandlers-doc-changed-options}
 
-The options object configures additional webhook behavior. 
+The options object configures additional webhook behavior.
 
-Available options include:
-
-* `winning_rev_only`
-
-Set `winning_rev_only` to `true` to fire the webhook only when the change involves the winning revision.
+Configure options in webhooks by setting the `"winning_rev_only": true` in the options object.
+Set `winning_rev_only` to fire the webhook only when the change involves the winning revision.
 This reduces webhook noise during conflict resolution by skipping events for removed non-winning revisions.
 
 NOTE: If an earlier winning revision becomes the winner again, Sync Gateway may still send duplicate events.
@@ -152,8 +149,8 @@ Verify your webhook client handles duplicate events appropriately.
 Simple Webhook::
 +
 --
-In this simple example of a `webhook` event handler we define a single instance with no filter.
-It simply listens for the `document_changed` event and immediately sends the changed document to the URL `+http://someurl.com+`.
+In this example of a `webhook` event handler you define a single instance with no filter.
+It listens for the `document_changed` event and sends the changed document to the URL `+http://someurl.com+`.
 
 [source,javascript]
 ----
@@ -174,11 +171,11 @@ It simply listens for the `document_changed` event and immediately sends the cha
 Multiple Webhooks::
 +
 --
-In this example you define two `webhook` event handlers with different configurations. 
+In this example you define two `webhook` event handlers with different configurations.
 
 The first handler uses both a `filter` and the `winning_rev_only` option, while the second handler uses only a `filter` to decide how to process the changed document.
 
-The `filter` function in the first handler recognizes documents with `doc.type` equal to `A` and posts the documents to the URL `+http://someurl.com/type_A+`. 
+The `filter` function in the first handler recognizes documents with `doc.type` equal to `A` and posts the documents to the URL `+http://someurl.com/type_A+`.
 
 This handler also uses the `winning_rev_only` option to prevent webhook spam during conflict resolution.
 

--- a/modules/ROOT/pages/webhooks.adoc
+++ b/modules/ROOT/pages/webhooks.adoc
@@ -124,6 +124,25 @@ Sets the address to which documents are posted.
 
 --
 
+Options::
++
+--
+Property name: {configuration-schema-database--xref--eventhandlers-doc-changed-options}
+
+The options object configures additional webhook behavior. 
+
+Available options include:
+
+* `winning_rev_only`
+
+Set `winning_rev_only` to `true` to fire the webhook only when the change involves the winning revision.
+This reduces webhook noise during conflict resolution by skipping events for removed non-winning revisions.
+
+NOTE: If an earlier winning revision becomes the winner again, Sync Gateway may still send duplicate events.
+Verify your webhook client handles duplicate events appropriately.
+
+--
+
 [#ex-definitions]
 .Sample Webhook Definitions
 =====
@@ -143,6 +162,9 @@ It simply listens for the `document_changed` event and immediately sends the cha
         {
             "handler": "webhook",
             "url": "http://someurl.com"
+            "options": {
+                "winning_rev_only": true
+            }
         }
     ]
 }
@@ -152,11 +174,15 @@ It simply listens for the `document_changed` event and immediately sends the cha
 Multiple Webhooks::
 +
 --
-In this example we define two `webhook` event handlers, both of which use filters to decide how to process the changed document.
+In this example you define two `webhook` event handlers with different configurations. 
 
-The `filter` function in the first handler recognizes documents with `doc.type` equal to `A` and posts the documents to the URL `+http://someurl.com/type_A+`.
+The first handler uses both a `filter` and the `winning_rev_only` option, while the second handler uses only a `filter` to decide how to process the changed document.
 
-The `filter` function in the second handler recognizes documents with `doc.type` equal to B and posts the documents to the URL `+http://someurl.com/type_B+`.
+The `filter` function in the first handler recognizes documents with `doc.type` equal to `A` and posts the documents to the URL `+http://someurl.com/type_A+`. 
+
+This handler also uses the `winning_rev_only` option to prevent webhook spam during conflict resolution.
+
+The `filter` function in the second handler recognizes documents with `doc.type` equal to `B` and posts the documents to the URL `+http://someurl.com/type_B+`.
 
 [source,javascript]
 ----
@@ -164,6 +190,9 @@ The `filter` function in the second handler recognizes documents with `doc.type`
       "document_changed": [
         {"handler": "webhook",
          "url": "http://someurl.com/type_A",
+         "options": {
+            "winning_rev_only": true
+         },
          "filter": `function(doc) {
               if (doc.type == "A") {
                 return true;


### PR DESCRIPTION
Docs Issue: [DOC-10217](https://jira.issues.couchbase.com/browse/DOC-10217)

PR to add winning_rev_only document_change webhook option 

[Docs Preview](https://preview.docs-test.couchbase.com/docs-sync-gateway-DOC-10217-document-rev_only-webhook-option/sync-gateway/current/webhooks.html)

 [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords).

[DOC-10217]: https://couchbasecloud.atlassian.net/browse/DOC-10217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ