### PR TITLE
fix: move intro page up to 3.3

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -11,7 +11,7 @@
 //
 
 .Start Here!
-* xref:index.adoc[Quick Links]
+// * xref:index.adoc[Quick Links]
 * xref:get-started-prepare.adoc[Prepare]
 * xref:get-started-install.adoc[Install]
 * xref:get-started-verify-install.adoc[Verify]

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -32,15 +32,18 @@ include::partial$_set_page_context.adoc[]
 <div class="card-row">
 ++++
 
-[.column]
-====== {empty}
-[.content]
-include::page$introduction.adoc[tags=intro]
+Sync Gateway is a secure, high-performance gateway designed for cloud-to-edge data synchronization.
+It serves as the synchronization server in a Couchbase Mobile deployment, enabling mobile, web, and IoT applications to view and sync data with Couchbase Server.
 
-[.column]
-====== {empty}
-[.media-left]
-image::cbm-architecture.png[,300]
+// [.column]
+// ====== {empty}
+// [.content]
+// include::page$introduction.adoc[tags=intro]
+
+// [.column]
+// ====== {empty}
+// [.media-left]
+// image::cbm-architecture.png[,300]
 
 ++++
 </div>

--- a/modules/ROOT/pages/introduction.adoc
+++ b/modules/ROOT/pages/introduction.adoc
@@ -1,32 +1,17 @@
-= Introduction
-ifdef::show_edition[:page-edition: {release}]
-ifdef::prerelease[:page-status: {prerelease}]
-:page-role:
-:page-partial:
-:description: pass:q[A short introduction to _Couchbase's Sync Gateway_ and how to get started using it.]
+= Sync Gateway
+:navtitle: Sync Gateway
+:description: Sync Gateway is a secure, high-performance gateway designed for cloud-to-edge data synchronization.
+// Handles boilerplate logic for landing page tiles layout
+:page-role: tiles -toc
+:!sectids:
 
 
-include::partial$_set_page_context.adoc[]
 
+Sync Gateway is a secure, high-performance gateway designed for cloud-to-edge data synchronization.
+It serves as the synchronization server in a Couchbase Mobile deployment, enabling mobile, web, and IoT applications to view and sync data with Couchbase Server.
 
-// BEGIN -- Page Heading
-:topic-group: Start Here!
-:param-abstract: pass:q[This is *Step 1* in Sync Gateway's Start Here! topic group.]
-:param-related: {get-started-prepare--xref}  |  {get-started-install--xref}  |  {get-started-verify-install--xref}
-include::partial$_show_page_header_block.adoc[]
-// END -- Page Heading
-
-
-== Getting Started with Sync Gateway
-
-:param-page: {page-relative-src-path}
-include::partial$topic-group-get-started.adoc[]
-
-// tag::intro[]
-Sync Gateway is the synchronization server in a Couchbase Mobile deployment.
-It is designed to provide data synchronization for large-scale interactive web, mobile, and IoT applications
-// end::intro[]
--- see: <<fig-mobile-server>>.
+You can use Sync Gateway in conjunction with Couchbase Lite for full Bi-directional sync between edge devices and the cloud.
+It provides fine-grained access control, RESTful API, and secure sync capabilities.
 
 [#fig-mobile-server]
 .Couchbase Mobile -- Deployment Architecture
@@ -34,22 +19,145 @@ image::cbm-architecture.png[]
 
 As you can see from <<fig-mobile-server>> Sync Gateway synchronizes changes made by web clients through its REST API, Couchbase Lite mobile-device applications, and Couchbase Server buckets.
 
-You can read more about the Data Synchronization process in {sync-with-couchbase-server--xref}.
-Some of its most central, and commonly used features, are those used to ensure secure **Access Control**.
+You can read more about the Data Synchronization process in xref:sync-with-couchbase-server.adoc[Sync with Couchbase Server].
+Some of its most central, and commonly used features, are those used to secure xref:access-control-model.adoc[Access Control].
 
 Sync Gateway assures secure access control using:
 
 * **User authentication**, which ensures that only authorized users can connect to Sync Gateway.
 For more information see the
-{users--xref}, {roles--xref} and {authentication-users--xref} content.
+xref:users.adoc[Users], xref:roles.adoc[Roles] and xref:authentication-users.adoc[User Authentication] content.
 
-* *Data Routing*, which ensures that authorized users can only access documents in those {channels--xref} assigned to them and only in accordance with their assigned privileges.
-You can set those privileges to confer {read-access--xref} and-or {write-access--xref} as required.
+* *Data Routing*, which ensures that authorized users can only access documents in those xref:channels.adoc[Channels] assigned to them and only in accordance with their assigned privileges.
+You can set those privileges to confer xref:access-control-how-control-document-access.adoc#lbl-read-access[Read Access] and-or xref:access-control-how-control-document-access.adoc#lbl-write-access[Write Access] as required.
 
-The business logic behind the validation and authorization of document access is provided by the customizable {sync-function--xref}.
+The business logic behind the validation and authorization of document access is provided by the customizable xref:sync-function.adoc[Sync Function].
+
+== Why Use Sync Gateway?
+
+* Bi-directional synchronization: Sync data between Couchbase Lite clients and Couchbase Server with real-time updates.
+
+* Secure access control: Supports RBAC, channels, and sync functions.
+
+* RESTful API: Public, Admin and Metric REST API interfaces for data and configuration access.
+
+* Scalable architecture: Designed for high-throughput, cloud-to-edge synchronization.
+
+== Key Capabilities
+
+* Fine-grained data distribution using channels for efficient synchronization.
+
+* Sync Function support: Customizable business logic for validation, transformation, and access control.
+
+* Role-Based Access Control.
+
+* RESTful API: Public, Admin and Metric REST API interfaces for data and configuration access.
+
+* Integration with Couchbase Lite and Couchbase Server.
+
+* Supports peer-to-peer, cloud, and hybrid sync topologies.
+
+// We need to go up one heading level to break the previous h2 div (with flex-basis 50%).
+= {empty}
+
+[.full-width-tile]
+TIP: For more information about the latest changes to Sync Gateway, see xref:whatsnew.adoc[].
 
 
-// BEGIN -- Page Footer
-include::partial$block-related-content-deploy.adoc[]
-// END -- Page Footer
+== Get Started
 
+Get started with Sync Gateway, from preparing your environment to installing and verifying your installation.
+
+* xref:get-started-prepare.adoc[Prepare your environment]
+* xref:get-started-install.adoc[Install Sync Gateway]
+* xref:get-started-verify-install.adoc[Verify your installation]
+
+== Data Modeling
+
+Learn how to design and structure your data buckets and documents using Sync Gateway.
+
+* xref:data-modeling.adoc[]
+
+== Configuration
+
+Learn how to configure Sync Gateway for cloud to edge synchronization including bootstrap, database settings, security, and more.
+
+* xref:configuration-schema-bootstrap.adoc[]
+* xref:configuration-schema-database.adoc[]
+* xref:configuration-schema-db-security.adoc[]
+* xref:configuration-schema-access-control.adoc[]
+* xref:configuration-schema-import-filter.adoc[]
+* xref:configuration-schema-isgr.adoc[]
+* xref:configuration-javascript-functions.adoc[]
+* xref:configuration-environment-variables.adoc[]
+
+== Security
+
+Implement comprehensive security measures to protect your data and control access to Sync Gateway.
+
+* xref:secure-sgw-access.adoc[]
+* xref:authentication-users.adoc[]
+* xref:authentication-certs.adoc[]
+* xref:audit-logging.adoc[]
+
+== Access Control
+
+Configure fine-grained access control with users, roles, channels, and sync functions.
+
+* xref:access-control-concepts.adoc[]
+* xref:sync-function.adoc[]
+* xref:access-contrlol-how.adoc[How to]
+* xref:auto-purge-channel-access-revocation.adoc[]
+
+== REST API
+
+Interact with Sync Gateway programmatically using comprehensive REST API interfaces.
+
+* xref:rest-api-access.adoc[]
+* xref:rest-api-admin.adoc[]
+* xref:rest-api-metrics.adoc[]
+* xref:rest-api.adoc[]
+* xref:rest-api-access-rbac-roles.adoc[]
+
+== Sync
+
+Synchronize data between Sync Gateway and your applications, servers, and other Sync Gateway instances.
+
+* xref:sync-with-server.adoc[]
+* xref:sync-using-app.adoc[]
+* xref:inter-syncgateway-overview.adoc[]
+* xref:delta-sync.adoc[]
+* xref:import-processing.adoc[]
+
+== Manage
+
+Perform administrative and operational tasks to maintain and monitor Sync Gateway.
+
+* xref:revisions.adoc[]
+* xref:managing-tombstones.adoc[]
+* xref:resync.adoc[]
+* xref:stats-monitoring.adoc[]
+* xref:database-offline.adoc[]
+* xref:logging.adoc[]
+
+== Deploy
+
+Deploy Sync Gateway in production environments with scalability and reliability considerations.
+
+* xref:command-line-options.adoc[]
+* xref:load-balancer.adoc[]
+* xref:webhooks.adoc[]
+* xref:stats-prometheus.adoc[]
+* xref:indexing.adoc[]
+* xref:deploy-cluster-to-kubernetes.adoc[]
+
+== Server Compatibility
+
+Understand Sync Gateway compatibility with Couchbase Server features and services.
+
+* xref:server-compatibility-buckets.adoc[Buckets]
+* xref:server-compatibility-collections.adoc[Collections]
+* xref:server-compatibility-eventing.adoc[Eventing]
+* xref:server-compatibility-transactions.adoc[Transactions]
+* xref:server-compatibility-xdcr.adoc[XDCR]
+* xref:server-compatibility-backups.adoc[Backup and Restore]

--- a/modules/ROOT/partials/landing-page-tiles-layout.adoc
+++ b/modules/ROOT/partials/landing-page-tiles-layout.adoc
@@ -1,0 +1,20 @@
+:page-role: tiles -toc
+:!sectids:
+
+// Pass through HTML styles for this page.
+ifdef::basebackend-html[]
+++++
+<style type="text/css">
+  /* Extend heading across page width */
+  div.page-heading-title,
+  div.contributor-list-box,
+  div#preamble,
+  nav.pagination {
+    flex-basis: 100%;
+  }
+.full-width-tip {
+  flex-basis: 100%;
+}
+</style>
+++++
+endif::[]


### PR DESCRIPTION
PR to move intro page to release 3.3 


Docs Preview: [URL](https://preview.docs-test.couchbase.com/docs-sync-gateway-DOC-13353-update-SGW-intro-page-for-3.3/sync-gateway/current/whatsnew.html)

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence. 

[DOC-13353]: https://couchbasecloud.atlassian.net/browse/DOC-13353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ