### PR TITLE
added page aliases to all docs pages

### DIFF
--- a/modules/ROOT/pages/access-control/access-control-concepts.adoc
+++ b/modules/ROOT/pages/access-control/access-control-concepts.adoc
@@ -1,4 +1,5 @@
 = Access Control Concepts
+:page-aliases: access-control-concepts.adoc
 // BEGIN -- PAGE -- access-control-model.adoc
 // BEGIN PAGE DEFINITION
 //  LOCATION modules/ROOT/pages/

--- a/modules/ROOT/pages/access-control/access-control-how-assign-users-to-roles.adoc
+++ b/modules/ROOT/pages/access-control/access-control-how-assign-users-to-roles.adoc
@@ -1,4 +1,5 @@
 = How to Assign Users to Roles
+:page-aliases: access-control-how-assign-users-to-roles.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :description: pass:q[How to assign a Sync Gateway _User_ one or more roles for secure access control in cloud-to-edge enterprise data synchronization.]

--- a/modules/ROOT/pages/access-control/access-control-how-control-document-access.adoc
+++ b/modules/ROOT/pages/access-control/access-control-how-control-document-access.adoc
@@ -1,4 +1,5 @@
 = Control Document Access
+:page-aliases: access-control-how-control-document-access.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :description: pass:q[How to control read/write/delete access using Sync Gateway's Sync Function API to ensure secure access to data in cloud-to-edge enterprise data synchronization.]

--- a/modules/ROOT/pages/access-control/access-control-how-create-roles.adoc
+++ b/modules/ROOT/pages/access-control/access-control-how-create-roles.adoc
@@ -1,4 +1,5 @@
 = How to Create a Role
+:page-aliases: access-control-how-create-roles.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :description: pass:q[How to create a Sync Gateway _Role_ for secure access control in cloud-to-edge enterprise data synchronization.]

--- a/modules/ROOT/pages/access-control/access-control-how-create-users.adoc
+++ b/modules/ROOT/pages/access-control/access-control-how-create-users.adoc
@@ -1,4 +1,5 @@
 = How to Create a User
+:page-aliases: access-control-how-create-users.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :description: pass:q[How to create a Sync Gateway user for secure access control in cloud-to-edge enterprise data synchronization.]

--- a/modules/ROOT/pages/access-control/access-control-how-use-xattrs-for-access-grants.adoc
+++ b/modules/ROOT/pages/access-control/access-control-how-use-xattrs-for-access-grants.adoc
@@ -1,4 +1,5 @@
 = Use Extended Attributes (XATTRs) for Access Grants
+:page-aliases: access-control-how-use-xattrs-for-access-grants.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :description: pass:q[How to set access grants using extended attributes (xattrs).]

--- a/modules/ROOT/pages/access-control/access-control-how-verify-access.adoc
+++ b/modules/ROOT/pages/access-control/access-control-how-verify-access.adoc
@@ -1,4 +1,5 @@
 = How to Verify Access
+:page-aliases: access-control-how-verify-access.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :description: pass:q[How to verify Sync Gateway access to data in cloud-to-edge enterprise data synchronization.]

--- a/modules/ROOT/pages/access-control/access-control-how.adoc
+++ b/modules/ROOT/pages/access-control/access-control-how.adoc
@@ -1,4 +1,5 @@
 = Access Control How-To
+:page-aliases: access-control-how.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 // BEGIN -- PAGE -- access-control-model.adoc

--- a/modules/ROOT/pages/access-control/access-control-model.adoc
+++ b/modules/ROOT/pages/access-control/access-control-model.adoc
@@ -1,4 +1,5 @@
 = Access Control Model
+:page-aliases: access-control-model.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :description: pass:q[An introduction to access control in Sync Gateway]

--- a/modules/ROOT/pages/access-control/auto-purge-channel-access-revocation.adoc
+++ b/modules/ROOT/pages/access-control/auto-purge-channel-access-revocation.adoc
@@ -1,5 +1,5 @@
 = Auto-Purge on Channel Access Revocation
-:page-aliases: anchor-auto-purge-channel-access-revocation
+:page-aliases: anchor-auto-purge-channel-access-revocation, auto-purge-channel-access-revocation.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :description: pass:q[Auto-purge behavior on loss of access to document channels]

--- a/modules/ROOT/pages/access-control/channels.adoc
+++ b/modules/ROOT/pages/access-control/channels.adoc
@@ -1,5 +1,5 @@
 = Channels
-:page-aliases: data-routing.adoc, learn/sync-gateway-channels.adoc, sync-gateway-channels.adoc
+:page-aliases: data-routing.adoc, learn/sync-gateway-channels.adoc, sync-gateway-channels.adoc, channels.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :description: pass:q[About Sync Gateway _Channels_ and their part in data routing and access control for secure cloud-to-edge enterprise data synchronization.]

--- a/modules/ROOT/pages/access-control/roles.adoc
+++ b/modules/ROOT/pages/access-control/roles.adoc
@@ -1,5 +1,5 @@
 = Roles
-:page-aliases: learn/roles.adoc
+:page-aliases: learn/roles.adoc, roles.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/access-control/sync-function/sync-function-api-access-cmd.adoc
+++ b/modules/ROOT/pages/access-control/sync-function/sync-function-api-access-cmd.adoc
@@ -1,4 +1,5 @@
 = Access()
+:page-aliases: sync-function-api-access-cmd.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/access-control/sync-function/sync-function-api-channel-cmd.adoc
+++ b/modules/ROOT/pages/access-control/sync-function/sync-function-api-channel-cmd.adoc
@@ -1,4 +1,5 @@
 = channel()
+:page-aliases: sync-function-api-channel-cmd.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/access-control/sync-function/sync-function-api-expiry-cmd.adoc
+++ b/modules/ROOT/pages/access-control/sync-function/sync-function-api-expiry-cmd.adoc
@@ -1,4 +1,5 @@
 = expiry()
+:page-aliases: sync-function-api-expiry-cmd.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/access-control/sync-function/sync-function-api-require-access-cmd.adoc
+++ b/modules/ROOT/pages/access-control/sync-function/sync-function-api-require-access-cmd.adoc
@@ -1,4 +1,5 @@
 = requireAccess()
+:page-aliases: sync-function-api-require-access-cmd.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/access-control/sync-function/sync-function-api-require-admin-cmd.adoc
+++ b/modules/ROOT/pages/access-control/sync-function/sync-function-api-require-admin-cmd.adoc
@@ -1,4 +1,5 @@
 = requireAdmin()
+:page-aliases: sync-function-api-require-admin-cmd.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/access-control/sync-function/sync-function-api-require-role-cmd.adoc
+++ b/modules/ROOT/pages/access-control/sync-function/sync-function-api-require-role-cmd.adoc
@@ -1,4 +1,5 @@
 = requireRole()
+:page-aliases: sync-function-api-require-role-cmd.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/access-control/sync-function/sync-function-api-require-user-cmd.adoc
+++ b/modules/ROOT/pages/access-control/sync-function/sync-function-api-require-user-cmd.adoc
@@ -1,4 +1,5 @@
 = requireUser()
+:page-aliases: sync-function-api-require-user-cmd.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/access-control/sync-function/sync-function-api-role-cmd.adoc
+++ b/modules/ROOT/pages/access-control/sync-function/sync-function-api-role-cmd.adoc
@@ -1,4 +1,5 @@
 = role()
+:page-aliases: sync-function-api-role-cmd.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/access-control/sync-function/sync-function-api-throw-cmd.adoc
+++ b/modules/ROOT/pages/access-control/sync-function/sync-function-api-throw-cmd.adoc
@@ -1,4 +1,5 @@
 = throw()
+:page-aliases: sync-function-api-throw-cmd.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/access-control/sync-function/sync-function-api.adoc
+++ b/modules/ROOT/pages/access-control/sync-function/sync-function-api.adoc
@@ -21,7 +21,7 @@
 //  INCLUSION USAGE
 // END PAGE DEFINITION
 = Sync Function API Reference
-:page-aliases: advance/adv-sgw-cfg-sync-function.adoc
+:page-aliases: advance/adv-sgw-cfg-sync-function.adoc, sync-function-api.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/access-control/sync-function/sync-function.adoc
+++ b/modules/ROOT/pages/access-control/sync-function/sync-function.adoc
@@ -1,4 +1,5 @@
 = Sync Function
+:page-aliases: sync-function.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/access-control/users.adoc
+++ b/modules/ROOT/pages/access-control/users.adoc
@@ -1,5 +1,5 @@
 = Users
-:page-aliases: learn/users-and-roles.adoc, users-and-roles.adoc
+:page-aliases: learn/users-and-roles.adoc, users-and-roles.adoc, users.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :description: pass:q[About Sync Gateway _users_ and their role in secure cloud-to-edge enterprise data synchronization.]

--- a/modules/ROOT/pages/configuration/configuration-environment-variables.adoc
+++ b/modules/ROOT/pages/configuration/configuration-environment-variables.adoc
@@ -1,4 +1,5 @@
 = Configuration Environment Variables
+:page-aliases: configuration-environment-variables.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/configuration/configuration-javascript-functions.adoc
+++ b/modules/ROOT/pages/configuration/configuration-javascript-functions.adoc
@@ -1,5 +1,6 @@
 // BEGIN -- PAGE -- config-external-javascript-functions.adoc
 = Using External Javascript Functions
+:page-aliases: configuration-javascript-functions.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/configuration/configuration-overview.adoc
+++ b/modules/ROOT/pages/configuration/configuration-overview.adoc
@@ -1,4 +1,5 @@
 = Configuration Overview
+:page-aliases: configuration-overview.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-content: conceptual

--- a/modules/ROOT/pages/configuration/configuration-properties-legacy.adoc
+++ b/modules/ROOT/pages/configuration/configuration-properties-legacy.adoc
@@ -1,5 +1,5 @@
 = Legacy Pre-3.0 Configuration
-:page-aliases: configuration-properties.adoc, refer/config-properties.adoc, config-properties.adoc
+:page-aliases: configuration-properties.adoc, refer/config-properties.adoc, config-properties.adoc, configuration-properties-legacy.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-status: Legacy Content
@@ -22,7 +22,7 @@ include::partial$_show_page_header_block.adoc[]
 // END -- DO NOT EDIT
 
 .Legacy Configuration
-IMPORTANT: You cannot use `collections` in Sync Gateway’s legacy Pre-3.0 configuration method. 
+IMPORTANT: You cannot use `collections` in Sync Gateway’s legacy Pre-3.0 configuration method.
 For current configuration details, see: {configuration-overview--xref} and-or {configuration-schema-bootstrap--xref}.
 
 == Introduction

--- a/modules/ROOT/pages/configuration/configuration-rest-api.adoc
+++ b/modules/ROOT/pages/configuration/configuration-rest-api.adoc
@@ -1,4 +1,5 @@
 = Configuration Rest API
+:page-aliases: configuration-rest-api.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/configuration/configuration-schema-access-control.adoc
+++ b/modules/ROOT/pages/configuration/configuration-schema-access-control.adoc
@@ -1,4 +1,5 @@
 = Access Control Configuration
+:page-aliases: configuration-schema-access-control.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :description: Using Sync Gateway's Admin REST API and the Sync function to configure access

--- a/modules/ROOT/pages/configuration/configuration-schema-bootstrap.adoc
+++ b/modules/ROOT/pages/configuration/configuration-schema-bootstrap.adoc
@@ -1,5 +1,6 @@
 
 = Bootstrap Configuration
+:page-aliases: configuration-schema-bootstrap.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/configuration/configuration-schema-database.adoc
+++ b/modules/ROOT/pages/configuration/configuration-schema-database.adoc
@@ -1,4 +1,5 @@
 = Database Configuration
+:page-aliases: configuration-schema-database.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/configuration/configuration-schema-db-security.adoc
+++ b/modules/ROOT/pages/configuration/configuration-schema-db-security.adoc
@@ -1,4 +1,5 @@
 = Database Security
+:page-aliases: configuration-schema-db-security.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-content: Reference

--- a/modules/ROOT/pages/configuration/configuration-schema-import-filter.adoc
+++ b/modules/ROOT/pages/configuration/configuration-schema-import-filter.adoc
@@ -1,4 +1,5 @@
 = Import Filter Configuration
+:page-aliases: configuration-schema-import-filter.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :description: Using Sync Gateway's Admin REST API and the Import Filter function to configure access

--- a/modules/ROOT/pages/configuration/configuration-schema-isgr.adoc
+++ b/modules/ROOT/pages/configuration/configuration-schema-isgr.adoc
@@ -1,4 +1,5 @@
 = Inter-Sync{nbsp}Gateway Replication Configuration
+:page-aliases: configuration-schema-isgr.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/configuration/scopes-and-collections-config.adoc
+++ b/modules/ROOT/pages/configuration/scopes-and-collections-config.adoc
@@ -1,5 +1,5 @@
 = Scopes and Collections Configuration for Sync Gateway
-:page-aliases: learn/scopes-and-collections-config.adoc
+:page-aliases: learn/scopes-and-collections-config.adoc, scopes-and-collections-config.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/deploy/changes-feed.adoc
+++ b/modules/ROOT/pages/deploy/changes-feed.adoc
@@ -1,5 +1,5 @@
 = Changes Feed
-:page-aliases: server-integration.adoc
+:page-aliases: server-integration.adoc, changes-feed.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :description: Integrating Sync Gateway with other servers
@@ -33,7 +33,7 @@ include::partial$server-integration-scenario-table.adoc[]
 
 The changes-feed for the receiver returns a sorted list of changes made to documents in the keyspace.
 
-This article describes using the changes feed API to integrate sync gateway with other backend processes. 
+This article describes using the changes feed API to integrate sync gateway with other backend processes.
 For instance, if you have a channel called 'needs-email', you could have a bot that sends an email and then saves the document with a flag to keep it out of the 'needs-email' channel.
 
 

--- a/modules/ROOT/pages/deploy/command-line-options.adoc
+++ b/modules/ROOT/pages/deploy/command-line-options.adoc
@@ -1,4 +1,5 @@
 = Using the Command Line
+:page-aliases: command-line-options.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :Description: Start a Sync Gateway instance using command line options and securely sync enterprise data from cloud to edge

--- a/modules/ROOT/pages/deploy/deployment.adoc
+++ b/modules/ROOT/pages/deploy/deployment.adoc
@@ -1,4 +1,5 @@
 = Deployment
+:page-aliases: deployment.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/deploy/index-partitions.adoc
+++ b/modules/ROOT/pages/deploy/index-partitions.adoc
@@ -1,4 +1,5 @@
 = Partitioned Indexes
+:page-aliases: index-partitions.adoc
 ifdef::show_edition[:page-edition: {release}]
 :page-status: Sync Gateway 3.3
 :page-role:

--- a/modules/ROOT/pages/deploy/indexing.adoc
+++ b/modules/ROOT/pages/deploy/indexing.adoc
@@ -1,4 +1,5 @@
 = Indexing
+:page-aliases: indexing.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/deploy/load-balancer.adoc
+++ b/modules/ROOT/pages/deploy/load-balancer.adoc
@@ -1,4 +1,5 @@
 = Load Balancer
+:page-aliases: load-balancer.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-toclevels: 1@

--- a/modules/ROOT/pages/deploy/os-level-tuning.adoc
+++ b/modules/ROOT/pages/deploy/os-level-tuning.adoc
@@ -1,4 +1,5 @@
 = OS Level Tuning
+:page-aliases: os-level-tuning.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-toclevels: 1@

--- a/modules/ROOT/pages/deploy/setting-up-dr-cluster.adoc
+++ b/modules/ROOT/pages/deploy/setting-up-dr-cluster.adoc
@@ -1,5 +1,6 @@
 = Setting up Disaster Recovery
 :page-layout: article
+:page-aliases: setting-up-dr-cluster.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/deploy/stats-prometheus.adoc
+++ b/modules/ROOT/pages/deploy/stats-prometheus.adoc
@@ -1,4 +1,5 @@
 = Integrate Prometheus
+:page-aliases: stats-prometheus.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/deploy/webhooks.adoc
+++ b/modules/ROOT/pages/deploy/webhooks.adoc
@@ -1,4 +1,5 @@
 = Webhooks
+:page-aliases: webhooks.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-toclevels: 1@

--- a/modules/ROOT/pages/manage/database-offline.adoc
+++ b/modules/ROOT/pages/manage/database-offline.adoc
@@ -1,4 +1,5 @@
 = Take Database Offline/Online
+:page-aliases: database-offline.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/manage/logging.adoc
+++ b/modules/ROOT/pages/manage/logging.adoc
@@ -18,7 +18,7 @@
 //  INCLUSION USAGE
 // END PAGE DEFINITION
 = Logging
-:page-aliases: advance/logging.adoc
+:page-aliases: advance/logging.adoc, logging.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/manage/managing-tombstones.adoc
+++ b/modules/ROOT/pages/manage/managing-tombstones.adoc
@@ -1,5 +1,5 @@
 = Tombstones
-:page-aliases: learn/concept-tombstones.adoc, learn/concept-fundamentals-data-tombstones.adoc, learn/what-are-tombstones.adoc, what-are-tombstones.adoc
+:page-aliases: learn/concept-tombstones.adoc, learn/concept-fundamentals-data-tombstones.adoc, learn/what-are-tombstones.adoc, what-are-tombstones.adoc, managing-tombstones.adoc
 :description: pass:q[Sync Gateway's _Tombstones_ are the means by which mobile clients are notified that a document has been deleted.]
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]

--- a/modules/ROOT/pages/manage/resync.adoc
+++ b/modules/ROOT/pages/manage/resync.adoc
@@ -1,4 +1,5 @@
 = Resync
+:page-aliases: resync.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/manage/revisions.adoc
+++ b/modules/ROOT/pages/manage/revisions.adoc
@@ -1,4 +1,5 @@
 = Revisions
+:page-aliases: revisions.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-toclevels: 2@

--- a/modules/ROOT/pages/manage/sgcollect-info.adoc
+++ b/modules/ROOT/pages/manage/sgcollect-info.adoc
@@ -1,4 +1,5 @@
 = SG Collect Info
+:page-aliases: sgcollect-info.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/manage/stats-monitoring-json.adoc
+++ b/modules/ROOT/pages/manage/stats-monitoring-json.adoc
@@ -1,4 +1,5 @@
 = JSON Metrics
+:page-aliases: stats-monitoring-json.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/manage/stats-monitoring-prometheus.adoc
+++ b/modules/ROOT/pages/manage/stats-monitoring-prometheus.adoc
@@ -1,4 +1,5 @@
 = Prometheus Metrics
+:page-aliases: stats-monitoring-prometheus.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/manage/stats-monitoring.adoc
+++ b/modules/ROOT/pages/manage/stats-monitoring.adoc
@@ -1,4 +1,5 @@
 = View Statistics and Metrics
+:page-aliases: stats-monitoring.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/rest-api/rest-api-access-rbac-roles.adoc
+++ b/modules/ROOT/pages/rest-api/rest-api-access-rbac-roles.adoc
@@ -1,5 +1,6 @@
 = RBAC Role -- Endpoint Cross-reference
 :page-partials:
+:page-aliases: rest-api-access-rbac-roles.adoc
 :page-edition: {release}
 :page-role:
 :page-content: Reference
@@ -938,7 +939,7 @@ Full Admin
 2+| Couchbase Server Release
 | Endpoint | Method | Pre 7.0.2 | 7.0.2+
 
- 
+
 | \{cluster}/metrics
 | GET
 | Cluster Admin Role,

--- a/modules/ROOT/pages/rest-api/rest-api-access.adoc
+++ b/modules/ROOT/pages/rest-api/rest-api-access.adoc
@@ -1,5 +1,5 @@
 = Secure API Access
-:page-aliases: start/rest-api-access.adoc, start/get-started-access-rest-api.adoc, get-started-access-rest-api.adoc
+:page-aliases: start/rest-api-access.adoc, start/get-started-access-rest-api.adoc, get-started-access-rest-api.adoc, rest-api-access.adoc
 :page-partials:
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
@@ -150,7 +150,7 @@ h| Full Admin
 For more information on older, end-of-life versions, see xref:3.0@rest-api-access.adoc[legacy version role availability].
 
 [#more-on-developer-previews]
-^1^For more information on Developer Previews, see xref:server:developer-preview:preview-mode.adoc[] 
+^1^For more information on Developer Previews, see xref:server:developer-preview:preview-mode.adoc[]
 
 For more on creating Couchbase Server users see the Couchbase Server content here {server-manage-security-users-and-roles--xref}.
 

--- a/modules/ROOT/pages/rest-api/rest-api-admin.adoc
+++ b/modules/ROOT/pages/rest-api/rest-api-admin.adoc
@@ -1,5 +1,5 @@
 = Admin REST API
-:page-aliases: refer/rest-api-admin.adoc
+:page-aliases: refer/rest-api-admin.adoc, rest-api-admin.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role: -toc

--- a/modules/ROOT/pages/rest-api/rest-api-metrics.adoc
+++ b/modules/ROOT/pages/rest-api/rest-api-metrics.adoc
@@ -1,5 +1,5 @@
 = Metrics REST API
-:page-aliases: refer/rest-api-metrics.adoc
+:page-aliases: refer/rest-api-metrics.adoc, rest-api-metrics.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/rest-api/rest-api.adoc
+++ b/modules/ROOT/pages/rest-api/rest-api.adoc
@@ -1,5 +1,5 @@
 = Public REST API
-:page-aliases: refer/rest-api-public.adoc
+:page-aliases: refer/rest-api-public.adoc, rest-api.adoc
 :page-role: -toc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]

--- a/modules/ROOT/pages/rest-api/rest_api_admin.adoc
+++ b/modules/ROOT/pages/rest-api/rest_api_admin.adoc
@@ -1,7 +1,7 @@
 :page-layout: rest-api
+:page-aliases: rest-api-admin.adoc, rest_api_admin_static.adoc, rest_api_admin.adoc
 :doctitle: Sync Gateway Admin API Reference
 :navtitle: Admin API Reference
-:page-aliases: rest_api_admin_static.adoc
 
 ++++
 include::partial$sgw-openapi-admin.html[]

--- a/modules/ROOT/pages/rest-api/rest_api_admin.adoc
+++ b/modules/ROOT/pages/rest-api/rest_api_admin.adoc
@@ -1,5 +1,5 @@
 :page-layout: rest-api
-:page-aliases: rest-api-admin.adoc, rest_api_admin_static.adoc, rest_api_admin.adoc
+:page-aliases: rest_api_admin_static.adoc, rest_api_admin.adoc
 :doctitle: Sync Gateway Admin API Reference
 :navtitle: Admin API Reference
 

--- a/modules/ROOT/pages/rest-api/rest_api_metric.adoc
+++ b/modules/ROOT/pages/rest-api/rest_api_metric.adoc
@@ -1,7 +1,7 @@
 :page-layout: rest-api
 :doctitle: Sync Gateway Metrics API Reference
 :navtitle: Metrics API Reference
-:page-aliases: rest_api_metrics_static.adoc
+:page-aliases: rest_api_metrics_static.adoc, rest_api_metric.adoc
 
 ++++
 include::partial$sgw-openapi-metric.html[]

--- a/modules/ROOT/pages/rest-api/rest_api_public.adoc
+++ b/modules/ROOT/pages/rest-api/rest_api_public.adoc
@@ -1,7 +1,7 @@
 :page-layout: rest-api
 :doctitle: Sync Gateway Public API Reference
 :navtitle: Public API Reference
-:page-aliases: rest_api_public_static.adoc
+:page-aliases: rest_api_public_static.adoc, rest_api_public.adoc
 
 ++++
 include::partial$sgw-openapi-public.html[]

--- a/modules/ROOT/pages/security/audit-log-events.adoc
+++ b/modules/ROOT/pages/security/audit-log-events.adoc
@@ -1,4 +1,5 @@
 = Audit Logging Events Reference
+:page-aliases: audit-log-events.adoc
 :page-edition: Enterprise
 :description: Audit Logging provides tools for administrators to track operational irregularities and to support regulatory and security compliance standards, such as link:https://www.hhs.gov/hipaa/index.html[HIPAA] and link:https://soc2.co.uk/soc2[SOC-2]. Below is a list of possible Audit Events.
 

--- a/modules/ROOT/pages/security/audit-logging.adoc
+++ b/modules/ROOT/pages/security/audit-logging.adoc
@@ -1,4 +1,5 @@
 = Audit Logging
+:page-aliases: audit-logging.adoc
 :page-edition: Enterprise
 :description: Audit Logging provides tools for administrators to track operational irregularities and to support regulatory and security compliance standards.
 

--- a/modules/ROOT/pages/security/authentication-certs.adoc
+++ b/modules/ROOT/pages/security/authentication-certs.adoc
@@ -1,5 +1,5 @@
 = TLS Certificate Authentication
-:page-aliases: deployment-considerations,configuring-ssl, security.adoc
+:page-aliases: deployment-considerations,configuring-ssl, security.adoc, authentication-certs.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :description: Securing Couchbase Sync Gateway with TLS Authentication

--- a/modules/ROOT/pages/security/authentication-users.adoc
+++ b/modules/ROOT/pages/security/authentication-users.adoc
@@ -1,5 +1,5 @@
 = User Authentication
-:page-aliases: learn/authentication.adoc, authentication.adoc
+:page-aliases: learn/authentication.adoc, authentication.adoc, authentication-users.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :description: Access {sgw} securely to sync from cloud to edge

--- a/modules/ROOT/pages/security/manage-audit-logs.adoc
+++ b/modules/ROOT/pages/security/manage-audit-logs.adoc
@@ -1,4 +1,5 @@
 = Manage Audit Logs
+:page-aliases: manage-audit-logs.adoc
 :page-edition: Enterprise
 :description: Administrators can manage audit logs to track operational irregularities and to support regulatory and security compliance standards.
 

--- a/modules/ROOT/pages/security/secure-sgw-access.adoc
+++ b/modules/ROOT/pages/security/secure-sgw-access.adoc
@@ -1,4 +1,5 @@
 = Secure Sync Gateway Access
+:page-aliases: secure-sgw-access.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/server-compatibility/server-compatibility-backups.adoc
+++ b/modules/ROOT/pages/server-compatibility/server-compatibility-backups.adoc
@@ -1,4 +1,5 @@
 = Backup and Restore -- Server Compatibility
+:page-aliases: server-compatibility-backups.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:
@@ -22,15 +23,15 @@ include::partial$_show_page_header_block.adoc[]
 // END -- Page Header
 
 
-== Backups 
+== Backups
 
 
 [IMPORTANT]
 .Partial backups and restores.
 ====
-Sync Gateway does not support partial backups/restores. 
+Sync Gateway does not support partial backups/restores.
 
-Make sure that you perform full backups 
+Make sure that you perform full backups
 if you're planning to use them in conjunction with Sync Gateway
 ====
 

--- a/modules/ROOT/pages/server-compatibility/server-compatibility-buckets.adoc
+++ b/modules/ROOT/pages/server-compatibility/server-compatibility-buckets.adoc
@@ -1,4 +1,5 @@
 = Buckets -- Server Compatibility
+:page-aliases: server-compatibility-buckets.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:
@@ -37,23 +38,23 @@ Sync Gateway does not support non-default durability settings at the bucket leve
 Make sure your buckets have their bucket durability setting set to `None`.
 If this is not the case you'll get a xref:server:learn:data/durability.adoc#failure-scenarios[failure scenario], `Write while SyncWrite is pending`, and the attempt at a durable write fails.
 
-You can still use high durability settings when set on the client side. 
+You can still use high durability settings when set on the client side.
 For more information about how to configure client-level durability for durable writes, see xref:server:learn:data/durability.adoc#specifying-levels[specifying levels].
 
 == Time To Live (TTL)
 
 IMPORTANT: Document TTL is an Enterprise Edition only feature.
 
-Couchbase Server Enterprise Edition lets you have documents expire after a period of time, called the document’s Time To Live (TTL). 
-This feature only works in Couchbase and Ephemeral buckets. 
+Couchbase Server Enterprise Edition lets you have documents expire after a period of time, called the document’s Time To Live (TTL).
+This feature only works in Couchbase and Ephemeral buckets.
 It does not work in Memcached buckets.
 For more information, see xref:server:learn:data/expiration.adoc[].
 
 Sync Gateway does not support Bucket-level TTL, make sure your buckets have their `maxTTL` setting set to `0`.
 If the bucket setting has a non-zero `maxTTL` value set, Sync Gateway returns an error prompting you to set the value to `0` in the Couchbase Server Admin UI.
 
-Similarly, do not set Collection-level TTL (`maxTTL` on collections) as this can interfere with Sync Gateway's internal documents, including those with `_sync` prefixes and other system documents that are essential for proper operation. 
-If these system documents expire due to collection-level TTL, Sync Gateway may malfunction or fail to operate properly. 
+Similarly, do not set Collection-level TTL (`maxTTL` on collections) as this can interfere with Sync Gateway's internal documents, including those with `_sync` prefixes and other system documents that are essential for proper operation.
+If these system documents expire due to collection-level TTL, Sync Gateway may malfunction or fail to operate properly.
 You can use per-collection sync functions to set expiry on all documents within a collection when you need TTL-like behavior at the collection level, while preserving Sync Gateway's system documents.
 
 NOTE: You can still set Document expiration settings on individual documents.

--- a/modules/ROOT/pages/server-compatibility/server-compatibility-collections.adoc
+++ b/modules/ROOT/pages/server-compatibility/server-compatibility-collections.adoc
@@ -1,4 +1,5 @@
 = Collections -- Server Compatibility
+:page-aliases: server-compatibility-collections.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/server-compatibility/server-compatibility-eventing.adoc
+++ b/modules/ROOT/pages/server-compatibility/server-compatibility-eventing.adoc
@@ -1,4 +1,5 @@
 = Eventing -- Server Compatibility
+:page-aliases: server-compatibility-eventing.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:
@@ -54,7 +55,7 @@ For Sync Gateway versions that write import XATTRs:
 
 * Eventing now prevents duplicate mutations with the opt-in `import_mutation_aware` boolean flag.
 
-NOTE: If the `import_mutation_aware` flag is set to `true`, the performance of the Eventing function will drop because every mutation processed by Eventing will require a subdocument operation to maintain a cursor or progress for any Function that is sharing a Sync Gateway endpoint.  
+NOTE: If the `import_mutation_aware` flag is set to `true`, the performance of the Eventing function will drop because every mutation processed by Eventing will require a subdocument operation to maintain a cursor or progress for any Function that is sharing a Sync Gateway endpoint.
 
 The procedure to enable Sync Gateway support for an Eventing function is as follows:
 

--- a/modules/ROOT/pages/server-compatibility/server-compatibility-transactions.adoc
+++ b/modules/ROOT/pages/server-compatibility/server-compatibility-transactions.adoc
@@ -1,4 +1,5 @@
 = Transactions -- Server Compatibility
+:page-aliases: server-compatibility-transactions.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/server-compatibility/server-compatibility-xdcr.adoc
+++ b/modules/ROOT/pages/server-compatibility/server-compatibility-xdcr.adoc
@@ -1,4 +1,5 @@
 = XDCR -- Server Compatibility
+:page-aliases: server-compatibility-xdcr.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/server-compatibility/xdcr-active-active-eventing.adoc
+++ b/modules/ROOT/pages/server-compatibility/xdcr-active-active-eventing.adoc
@@ -1,4 +1,5 @@
 = XDCR Active-Active and Eventing
+:page-aliases: xdcr-active-active-eventing.adoc
 :description: pass:q[Understand how to safely use Couchbase Eventing functions in bi-directional XDCR environments, including Sync Gateway 4.0 compatibility.]
 :keywords: xdcr, eventing, active-active, sync gateway, replication, loop prevention, conflict resolution, enrichment, mobile, couchbase eventing, replication logic
 :idprefix:

--- a/modules/ROOT/pages/sync/delta-sync.adoc
+++ b/modules/ROOT/pages/sync/delta-sync.adoc
@@ -1,4 +1,5 @@
 = Delta Sync
+:page-aliases: delta-sync.adoc
 ifdef::show_edition[:page-edition: {release}] {enterprise}
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/sync/import-processing.adoc
+++ b/modules/ROOT/pages/sync/import-processing.adoc
@@ -1,5 +1,5 @@
 = Import Processing
-:page-aliases: import-filter.adoc
+:page-aliases: import-filter.adoc, import-processing.adoc
 include::partial$_set_page_context.adoc[]
 
 == Overview

--- a/modules/ROOT/pages/sync/sync-inter-syncgateway-conflict-resolution.adoc
+++ b/modules/ROOT/pages/sync/sync-inter-syncgateway-conflict-resolution.adoc
@@ -1,5 +1,5 @@
 = Enhanced Conflict Resolution
-:page-aliases: learn/icr-conflict-resolution.adoc
+:page-aliases: learn/icr-conflict-resolution.adoc, sync-inter-syncgateway-conflict-resolution.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/sync/sync-inter-syncgateway-manage.adoc
+++ b/modules/ROOT/pages/sync/sync-inter-syncgateway-manage.adoc
@@ -1,5 +1,5 @@
 = Manage Inter-Sync Gateway Replications
-:page-aliases: learn/icr-admin.adoc, icr-admin.adoc
+:page-aliases: learn/icr-admin.adoc, icr-admin.adoc, sync-inter-syncgateway-manage.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/sync/sync-inter-syncgateway-monitor.adoc
+++ b/modules/ROOT/pages/sync/sync-inter-syncgateway-monitor.adoc
@@ -1,5 +1,5 @@
 = Replication Monitoring and Statistics
-:page-aliases: learn/icr-monitoring.adoc, icr-monitoring.adoc
+:page-aliases: learn/icr-monitoring.adoc, icr-monitoring.adoc, sync-inter-syncgateway-monitor.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/sync/sync-inter-syncgateway-overview.adoc
+++ b/modules/ROOT/pages/sync/sync-inter-syncgateway-overview.adoc
@@ -1,5 +1,5 @@
 = Inter-Sync Gateway Replication
-:page-aliases: learn/icr-sgreplicate.adoc, icr-sgreplicate.adoc
+:page-aliases: learn/icr-sgreplicate.adoc, icr-sgreplicate.adoc, sync-inter-syncgateway-overview.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/sync/sync-inter-syncgateway-run.adoc
+++ b/modules/ROOT/pages/sync/sync-inter-syncgateway-run.adoc
@@ -1,5 +1,5 @@
 = Initialize Inter-Sync Gateway Replications
-:page-aliases: running-replications.adoc, learn/icr-running.adoc, icr-running.adoc
+:page-aliases: running-replications.adoc, learn/icr-running.adoc, icr-running.adoc, sync-inter-syncgateway-run.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:

--- a/modules/ROOT/pages/sync/sync-using-app.adoc
+++ b/modules/ROOT/pages/sync/sync-using-app.adoc
@@ -1,5 +1,5 @@
 = Sync with Couchbase Lite
-:page-aliases: sync-from-client.adoc
+:page-aliases: sync-from-client.adoc, sync-using-app.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role: -toc

--- a/modules/ROOT/pages/sync/sync-with-couchbase-server.adoc
+++ b/modules/ROOT/pages/sync/sync-with-couchbase-server.adoc
@@ -1,5 +1,5 @@
 = Sync with Couchbase Server
-:page-aliases: shared-bucket-access.adoc, sync-with-server.adoc
+:page-aliases: shared-bucket-access.adoc, sync-with-server.adoc, sync-with-couchbase-server.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-toclevels: 2@
@@ -138,9 +138,9 @@ SELECT meta().xattrs._sync FROM scope.collection WHERE meta().id = "mydocId"
 ----
 ====
 
-WARNING: {sgw} maintains the sync metadata internally, and its structure can change at any time. 
-Applications must not use it for business logic. 
-The direct use of the {sqlpp} query or modifying the internal sync metadata contents to drive the business logic is unsupported and must not be used in production environments. 
+WARNING: {sgw} maintains the sync metadata internally, and its structure can change at any time.
+Applications must not use it for business logic.
+The direct use of the {sqlpp} query or modifying the internal sync metadata contents to drive the business logic is unsupported and must not be used in production environments.
 The sync metadata includes the `_sync` extended attribute (XATTR) in use case documents and all `_sync:` prefixed documents in Sync Gateway connected Buckets.
 
 === Enable Shared Bucket Access

--- a/modules/ROOT/pages/use-kubernetes/deploy-cluster-to-kubernetes.adoc
+++ b/modules/ROOT/pages/use-kubernetes/deploy-cluster-to-kubernetes.adoc
@@ -18,7 +18,7 @@
 //  INCLUSION USAGE
 // END PAGE DEFINITION
 = Deploying a Sync Gateway Cluster
-:page-aliases: deploy-cluster.adoc, advance/kubernetes/deploy-cluster.adoc
+:page-aliases: deploy-cluster.adoc, advance/kubernetes/deploy-cluster.adoc, deploy-cluster-to-kubernetes.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :description: Connect Sync Gateway to a Server Cluster Deployed with CAO 1.2.x


### PR DESCRIPTION
Docs Issue: Add page alias for updating folder structure with sync gateway doc files 

Preview: [URL](https://preview.docs-test.couchbase.com/docs-sync-gateway-page-aliases-for-sgw/sync-gateway/current/introduction.html)

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords).