### PR TITLE
Doc 13452 fix product note link

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -136,9 +136,10 @@
   * xref:server-compatibility/server-compatibility-backups.adoc[Backup and Restore]
 
 .Product Notes
-  * xref:release-notes.adoc[Release Notes]
-  * xref:supported-environments.adoc[Supported Environments]
-  * xref:compatibility.adoc[Compatibility Matrix]
+  * xref:product-notes/release-notes.adoc[Release Notes]
+  * xref:product-notes/supported-environments.adoc[Supported Environments]
+  * xref:product-notes/compatibility.adoc[Compatibility Matrix]
+
 
 // list divider
 

--- a/modules/ROOT/pages/server-compatibility/server-compatibility-xdcr.adoc
+++ b/modules/ROOT/pages/server-compatibility/server-compatibility-xdcr.adoc
@@ -98,14 +98,14 @@ Even though Sync Gateway is the operational replicator of choice for mobile data
 
 === Clusters in Same Region
 
-include::setting-up-dr-cluster.adoc[tags=page-attributes]
+include::../deploy/setting-up-dr-cluster.adoc[tags=page-attributes]
 
-include::setting-up-dr-cluster.adoc[tags=clusters-in-same-region]
+include::../deploy/setting-up-dr-cluster.adoc[tags=clusters-in-same-region]
 
 
 === Clusters in Different Regions
 
-include::setting-up-dr-cluster.adoc[tags=clusters-in-diff-region]
+include::../deploy/setting-up-dr-cluster.adoc[tags=clusters-in-diff-region]
 
 // BEGIN -- Page Footer
 include::partial$block-related-content-sync.adoc[]

--- a/modules/ROOT/pages/sync/sync-with-couchbase-server.adoc
+++ b/modules/ROOT/pages/sync/sync-with-couchbase-server.adoc
@@ -138,9 +138,9 @@ SELECT meta().xattrs._sync FROM scope.collection WHERE meta().id = "mydocId"
 ----
 ====
 
-WARNING: {sgw} maintains the sync metadata internally, and its structure can change at any time. 
-Applications must not use it for business logic. 
-The direct use of the {sqlpp} query or modifying the internal sync metadata contents to drive the business logic is unsupported and must not be used in production environments. 
+WARNING: {sgw-t} maintains the sync metadata internally, and its structure can change at any time.
+Applications must not use it for business logic.
+The direct use of the {sqlpp} query or modifying the internal sync metadata contents to drive the business logic is unsupported and must not be used in production environments.
 The sync metadata includes the `_sync` extended attribute (XATTR) in use case documents and all `_sync:` prefixed documents in Sync Gateway connected Buckets.
 
 === Enable Shared Bucket Access


### PR DESCRIPTION
Docs Issue: [DOC-13452](https://jira.issues.couchbase.com/browse/DOC-13452)

PR to fix broken product notes link and update the file path for the includes on the XDCR page 

Preview: 
- [Product Notes](https://preview.docs-test.couchbase.com/docs-sync-gateway-DOC-13452-fix-product-note-link/sync-gateway/current/product-notes/release-notes.html)
- [Supported Environments](https://preview.docs-test.couchbase.com/docs-sync-gateway-DOC-13452-fix-product-note-link/sync-gateway/current/product-notes/supported-environments.html)
- [Compatibility Matrix](https://preview.docs-test.couchbase.com/docs-sync-gateway-DOC-13452-fix-product-note-link/sync-gateway/current/product-notes/compatibility.html)
- [XDCR](https://preview.docs-test.couchbase.com/docs-sync-gateway-DOC-13452-fix-product-note-link/sync-gateway/current/server-compatibility/server-compatibility-xdcr.html#clusters-in-different-regions)

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords).

[DOC-13452]: https://couchbasecloud.atlassian.net/browse/DOC-13452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ