### PR TITLE
fix whats new release note

### DIFF
--- a/modules/ROOT/pages/_partials/release_notes/sync-gateway-3-3-0-release-note.adoc
+++ b/modules/ROOT/pages/_partials/release_notes/sync-gateway-3-3-0-release-note.adoc
@@ -1,4 +1,4 @@
-== 3.3.0 -- July 2025
+== 3.3.0 -- August 2025
 
 include::partial$block-caveats.adoc[tags=eventing-mixed-mode]
 

--- a/modules/ROOT/pages/whatsnew.adoc
+++ b/modules/ROOT/pages/whatsnew.adoc
@@ -69,9 +69,7 @@ xref:3.2@sync-gateway:ROOT:whatsnew.adoc[What's new in previous version 3.2].
 
 === Sync Gateway Release Notes
 
-xref:_partials/release_notes/sync-gateway-3-3-0-release-note.adoc[Read the full 3.3 release notes here].
-
-xref:partial$_partials/release_notes/sync-gateway-3-3-0-release-note.adoc[Read the full 3.3 release notes here].
+xref:product-notes/release-notes.adoc[Read the full 3.3 release notes here].
 
 
 == Upgrading

--- a/modules/ROOT/pages/whatsnew.adoc
+++ b/modules/ROOT/pages/whatsnew.adoc
@@ -69,7 +69,10 @@ xref:3.2@sync-gateway:ROOT:whatsnew.adoc[What's new in previous version 3.2].
 
 === Sync Gateway Release Notes
 
-xref:3.3@release-notes.adoc[Read the full 3.3 release notes here].
+xref:_partials/release_notes/sync-gateway-3-3-0-release-note.adoc[Read the full 3.3 release notes here].
+
+xref:partial$_partials/release_notes/sync-gateway-3-3-0-release-note.adoc[Read the full 3.3 release notes here].
+
 
 == Upgrading
 


### PR DESCRIPTION
PR to fix the Release notes for 3.3 

Docs preview: [Preview URL](https://preview.docs-test.couchbase.com/docs-sync-gateway-fix-release-notes-3.3/sync-gateway/current/whatsnew.html#sync-gateway-release-notes)

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.