### PR TITLE
update 3.2.7 with maintenance

### DIFF
--- a/modules/ROOT/pages/_partials/release_notes/sync-gateway-3-2-7-release-note.adoc
+++ b/modules/ROOT/pages/_partials/release_notes/sync-gateway-3-2-7-release-note.adoc
@@ -1,0 +1,24 @@
+== 3.2.7 -- November 2025
+
+[#maint-3-2-7]
+=== Fixed Issues
+
+* https://jira.issues.couchbase.com/browse/CBG-4971[CBG-4971 - Allow cookieless authentication from cbl-js]
+
+* https://jira.issues.couchbase.com/browse/CBG-4940[CBG-4940 - Couchbase Lite 4.0 is allowed to connect to Sync Gateway 3.2.6/3.3.0]
+
+* https://jira.issues.couchbase.com/browse/CBG-4694[CBG-4694 - calling GET `/db/_session/sessionID` returns invalidated session]
+
+=== Enhancements
+
+None for this release.
+
+=== Known Issues
+
+None for this release.
+
+=== Deprecations
+
+None for this release.
+
+NOTE: For an overview of the latest features offered in Sync Gateway 3.2, see xref:whatsnew.adoc[New in 3.2].

--- a/modules/ROOT/pages/_partials/release_notes/sync-gateway-3-2-7-release-note.adoc
+++ b/modules/ROOT/pages/_partials/release_notes/sync-gateway-3-2-7-release-note.adoc
@@ -3,15 +3,13 @@
 [#maint-3-2-7]
 === Fixed Issues
 
-* https://jira.issues.couchbase.com/browse/CBG-4971[CBG-4971 - Allow cookieless authentication from cbl-js]
-
 * https://jira.issues.couchbase.com/browse/CBG-4940[CBG-4940 - Couchbase Lite 4.0 is allowed to connect to Sync Gateway 3.2.6/3.3.0]
 
 * https://jira.issues.couchbase.com/browse/CBG-4694[CBG-4694 - calling GET `/db/_session/sessionID` returns invalidated session]
 
 === Enhancements
 
-None for this release.
+* https://jira.issues.couchbase.com/browse/CBG-4971[CBG-4971 - Allow cookieless authentication from cbl-js]
 
 === Known Issues
 

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -43,6 +43,8 @@ The migration to 3.x configuration is a ONE WAY process -- see: {upgrading--xref
 :param-release-tag: -1
 
 [#maint-latest]
+include::partial$release_notes/sync-gateway-3-2-7-release-note.adoc[]
+
 include::partial$release_notes/sync-gateway-3-2-6-release-note.adoc[]
 
 include::partial$release_notes/sync-gateway-3-2-5-release-note.adoc[]


### PR DESCRIPTION
Docs Issue: [Issue 1358](https://jira.issues.couchbase.com/browse/CM-1358)

PR to uodate the release notes with maintenance releases for 3.2.7 


Preview: [URL](https://preview.docs-test.couchbase.com/docs-sync-gateway-CB-1364-release-note-3.2.7/sync-gateway/current/release-notes.html)

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.
