### PR TITLE
DOC-13771 update antora yml and add release note

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -13,7 +13,7 @@ asciidoc:
     release: '3.3'
     major: 3
     minor: 3
-    maintenance: 0
-    base: 0
+    maintenance: 2
+    base: 2
     page-toclevels: 2@
     # releasetag:

--- a/modules/ROOT/partials/release_notes/sync-gateway-3-3-0-release-note.adoc
+++ b/modules/ROOT/partials/release_notes/sync-gateway-3-3-0-release-note.adoc
@@ -5,11 +5,11 @@
 * https://jira.issues.couchbase.com/browse/CBG-5009[CBG-5009 - _ping (and all endpoints) acquire ServerContext.lock.RLock and blocks if the write lock is acquired]
 * https://jira.issues.couchbase.com/browse/CBG-5028[CBG-5028 - Have rev cache lock and rev cache value unlocks use defer where possible]
 * https://jira.issues.couchbase.com/browse/CBG-5030[CBG-5030 - Panic during memory based cache eviction can deadlock revision cache shard]
-* https://jira.issues.couchbase.com/browse/CBG-5035[CBG-5035 - Synchronize Computation of Deltas]
+
 
 === Enhancements
 
-None for this release.
+* https://jira.issues.couchbase.com/browse/CBG-5034[CBG-5034 - Synchronize Computation of Deltas]
 
 === Known Issues
 

--- a/modules/ROOT/partials/release_notes/sync-gateway-3-3-0-release-note.adoc
+++ b/modules/ROOT/partials/release_notes/sync-gateway-3-3-0-release-note.adoc
@@ -1,3 +1,24 @@
+== 3.3.2 -- December 2025
+
+=== Fixed Issues
+
+* https://jira.issues.couchbase.com/browse/CBG-5009[CBG-5009 - _ping (and all endpoints) acquire ServerContext.lock.RLock and blocks if the write lock is acquired]
+* https://jira.issues.couchbase.com/browse/CBG-5028[CBG-5028 - Have rev cache lock and rev cache value unlocks use defer where possible]
+* https://jira.issues.couchbase.com/browse/CBG-5030[CBG-5030 - Panic during memory based cache eviction can deadlock revision cache shard]
+* https://jira.issues.couchbase.com/browse/CBG-5035[CBG-5035 - Synchronize Computation of Deltas]
+
+=== Enhancements
+
+None for this release.
+
+=== Known Issues
+
+None for this release.
+
+=== Deprecations
+
+None for this release.
+
 == 3.3.1 -- November 2025
 
 === Fixed Issues


### PR DESCRIPTION
Docs Issue: [DOC-13771](https://jira.issues.couchbase.com/browse/DOC-13771?atlOrigin=eyJpIjoiMTBhNDQ0NTVlZWQxNGMyYjljNGI2Mjc0NjA3MDlkZjgiLCJwIjoiaiJ9)

PR to add release notes and update install page versions for SGW 

Preview: 

- [Release note](https://preview.docs-test.couchbase.com/docs-sync-gateway-DOC-13771-sgw-3.3.2/sync-gateway/current/product-notes/release-notes.html) 
- [Install page](https://preview.docs-test.couchbase.com/docs-sync-gateway-DOC-13771-sgw-3.3.2/sync-gateway/current/start-here/get-started-install.html)
You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.


[DOC-13771]: https://couchbasecloud.atlassian.net/browse/DOC-13771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ