### PR TITLE
update sync function and update style

### DIFF
--- a/modules/server-compatibility/pages/server-compatibility-eventing.adoc
+++ b/modules/server-compatibility/pages/server-compatibility-eventing.adoc
@@ -47,7 +47,7 @@ You can now create Eventing functions with read-write bindings with the source b
 
 You can also use Eventing to generate vector embeddings from document fields, see xref:couchbase-lite:ROOT/cbl-whatsnew.adoc#vector-search[Vector Search] for more details about Vector Search with Couchbase Lite.
 
-Eventing now skips all documents with IDs prefixed with `_sync`.
+An Eventing function, based on deployment options, can now skip all documents with IDs prefixed with `_sync`.
 
 For Sync Gateway versions that write import XATTRs:
 
@@ -55,7 +55,7 @@ For Sync Gateway versions that write import XATTRs:
 
 * Eventing now prevents duplicate mutations with the opt-in `import_mutation_aware` boolean flag.
 
-NOTE: If the `import_mutation_aware` flag is set to `true`, the performance of the Eventing function will drop because every mutation processed by Eventing will require a subdocument operation to maintain a cursor or progress for any Function that is sharing a Sync Gateway endpoint.
+NOTE: If the `import_mutation_aware` flag is set to `true`, the performance of the Eventing function drops because every mutation processed by Eventing requires a Sub-Document operation to maintain a cursor or state for any Function that's sharing a Sync Gateway endpoint.
 
 The procedure to enable Sync Gateway support for an Eventing function is as follows:
 
@@ -99,25 +99,25 @@ Where:
 +
 . On Couchbase Server, xref:server:eventing:eventing-api.adoc#basic_resume[resume the function].
 
-For more details, see xref:server:eventing:eventing-api.adoc[Eventing REST API].
+For more information, see xref:server:eventing:eventing-api.adoc[Eventing REST API].
 
 == Using Eventing (Pre-Server 7.6.3)
 
 You can use Eventing and Sync Gateway connected to the same bucket when Eventing operates on server buckets in *read only* mode -- see {server-eventing-terminologies--xref-bindings} for how to do this.
 
-You should write your Eventing function to be *idempotent*; to behave correctly when the same mutation is seen more than once.
+You should write your Eventing function to be *idempotent* so that it produces the same result when it processes the same mutation more than once.
 This is necessary because:
 
-* When a single document update is made directly by Sync Gateway, such as those replicated from Couchbase Lite, it generates a single server mutation that writes both the document body and the metadata.
+* When Sync Gateway makes a single document update directly, such as those replicated from Couchbase Lite, it generates a single server mutation that writes both the document body and the metadata.
 +
-When an update originates outside of Couchbase mobile then multiple mutations are generated because Sync Gateway must update both the document's body and its _sync metadata (XATTRs).
+When an update originates outside of Couchbase mobile, Sync Gateway generates multiple mutations because it must update both the document's body and its `_sync` metadata (XATTRs).
 
 * _Eventing_ detects these mutations and invokes its `OnUpdate` *for each*; whether it's for the modified body of the document, Sync Gateway metadata, or both.
-It is here that you need to code the function to apply the same update once only.
+It's here that you need to code the function to apply the same update once only.
 One way to do this is to use the crc64 function call to identify when an update is to the Sync Gateway metadata only -- see: {server-eventing-constructs-crc64--xref} for more on how to do this.
 
 _Eventing_ prevents inadvertent use of its functions on _Sync Gateway_ read-write buckets.
-You will see the following  warning if you try to do this: +
+You'll see the following warning if you try to do this: +
 `SyncGateway is enabled on: <bucket-name>, deployment of source bucket mutating handler will cause Intra Bucket Recursion`
 
 // BEGIN -- Page Footer

--- a/modules/server-compatibility/pages/server-compatibility-eventing.adoc
+++ b/modules/server-compatibility/pages/server-compatibility-eventing.adoc
@@ -113,7 +113,7 @@ This is necessary because:
 +
 When an update originates outside of Couchbase mobile, Sync Gateway generates multiple mutations because it must update both the document's body and its `_sync` metadata (XATTRs).
 
-* _Eventing_ detects these mutations and invokes its `OnUpdate` *for each*; whether it's for the modified body of the document, Sync Gateway metadata, or both.
+* Eventing detects these mutations and invokes its `OnUpdate` handler for each one; whether it's for the modified body of the document, Sync Gateway metadata, or both.
 It's here that you need to code the function to apply the same update once only.
 One way to do this is to use the crc64 function call to identify when an update is to the Sync Gateway metadata only -- see: {server-eventing-constructs-crc64--xref} for more on how to do this.
 

--- a/modules/server-compatibility/pages/server-compatibility-eventing.adoc
+++ b/modules/server-compatibility/pages/server-compatibility-eventing.adoc
@@ -55,7 +55,8 @@ For Sync Gateway versions that write import XATTRs:
 
 * Eventing now prevents duplicate mutations with the opt-in `import_mutation_aware` boolean flag.
 
-NOTE: If the `import_mutation_aware` flag is set to `true`, the performance of the Eventing function drops because every mutation processed by Eventing requires a Sub-Document operation to maintain a cursor or state for any Function that's sharing a Sync Gateway endpoint.
+NOTE: If the `import_mutation_aware` flag is set to `true`, the performance of the Eventing function drops. 
+This happens because every mutation processed by Eventing requires a Sub-Document operation to maintain a cursor or state for any function that shares a Sync Gateway endpoint.
 
 The procedure to enable Sync Gateway support for an Eventing function is as follows:
 

--- a/modules/server-compatibility/pages/server-compatibility-eventing.adoc
+++ b/modules/server-compatibility/pages/server-compatibility-eventing.adoc
@@ -106,7 +106,7 @@ For more information, see xref:server:eventing:eventing-api.adoc[Eventing REST A
 
 You can use Eventing and Sync Gateway connected to the same bucket when Eventing operates on server buckets in *read only* mode -- see {server-eventing-terminologies--xref-bindings} for how to do this.
 
-You should write your Eventing function to be *idempotent* so that it produces the same result when it processes the same mutation more than once.
+You should write your Eventing function to be idempotent so that it produces the same result when it processes the same mutation more than once.
 This is necessary because:
 
 * When Sync Gateway makes a single document update directly, such as those replicated from Couchbase Lite, it generates a single server mutation that writes both the document body and the metadata.


### PR DESCRIPTION
Docs Issue: [DOC-13255](https://jira.issues.couchbase.com/browse/DOC-13255?atlOrigin=eyJpIjoiMzJjNDJiMjVlZjI5NDhjYWEwNzAzY2E4YjZhOTJkMmUiLCJwIjoiaiJ9)

PR to clarify eventing _sync document skipping is per-function and fix style issues

Preview URL:
https://preview.docs-test.couchbase.com/docs-sync-gateway-DOC-13218-eventing-sg-compat-update

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.

[DOC-13255]: https://couchbasecloud.atlassian.net/browse/DOC-13255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ