### PR TITLE
update api reference url for 3.3

### DIFF
--- a/modules/ROOT/partials/_define_page_index.adoc
+++ b/modules/ROOT/partials/_define_page_index.adoc
@@ -622,6 +622,7 @@ endif::xref--pfx-sgw[]
 
 :rest-api--page: rest-api:rest-api.adoc
 :rest-api--xref: {sgw--xref}{rest-api--page}[Public REST API]
+:rest-api--xref--api-reference: {sgw--xref}rest-api:rest_api_public.adoc[API reference]
 
 // :configuration-schema-database--page: rest-api-admin-database.adoc
 // :configuration-schema-database--xref: {sgw--xref}{configuration-schema-database--page}[Database Configuration API]
@@ -640,6 +641,7 @@ endif::xref--pfx-sgw[]
 :rest-api-admin--page: rest-api:rest-api-admin.adoc
 :rest-api-admin--pfx: {sgw--xref}{rest-api-admin--page}
 :rest-api-admin--xref: {rest-api-admin--pfx}[Admin REST API]
+:rest-api-admin--xref--api-reference: {sgw--xref}rest-api:rest_api_admin.adoc[API reference]
 
 
 :rest-api-admin--pfx--database-configuration: xref:rest-api:rest_api_admin.adoc#tag/Database-Configuration
@@ -688,6 +690,7 @@ endif::xref--pfx-sgw[]
 
 :rest-api-metrics--page: rest-api:rest-api-metrics.adoc
 :rest-api-metrics--xref: {sgw--xref}{rest-api-metrics--page}[Metrics REST API]
+:rest-api-metrics--xref--api-reference: {sgw--xref}rest-api:rest_api_metric.adoc[API reference]
 
 :resync--page:  manage:resync.adoc
 :resync--xref: {sgw--xref}{resync--page}[Resync]

--- a/modules/manage/pages/stats-monitoring.adoc
+++ b/modules/manage/pages/stats-monitoring.adoc
@@ -22,9 +22,9 @@ include::ROOT:partial$_define_stats_item_names.adoc[]
 == Introduction
 
 Deployments are increasingly scaling to support large numbers of connected mobile and edge clients.
-This places added emphasis on the effective  monitoring of the health and performance of Sync Gateway nodes.
+This places added emphasis on the effective monitoring of the health and performance of Sync Gateway nodes.
 
-Sync Gateway's Metrics REST API_ facilitates the process of gathering this essential data by providing access to node metrics covering:
+Sync Gateway's Metrics REST API facilitates the process of gathering this essential data by providing access to node metrics covering:
 
 * Performance
 * Resource utilization

--- a/modules/rest-api/pages/rest-api-admin.adoc
+++ b/modules/rest-api/pages/rest-api-admin.adoc
@@ -28,7 +28,7 @@ Calls to `requireUser`, `requireAccess` and `requireRole` will be no-ops, and wi
 
 == API Reference
 
-The xref:rest-api:rest_api_admin.adoc[API reference] groups all the endpoints by functionality.
+The {rest-api-admin--xref--api-reference} groups all the endpoints by functionality.
 
 Each endpoint description specifies its RBAC role requirements, but see
 xref:rest-api:rest-api-access-rbac-roles.adoc[RBAC Roles]

--- a/modules/rest-api/pages/rest-api-metrics.adoc
+++ b/modules/rest-api/pages/rest-api-metrics.adoc
@@ -39,7 +39,7 @@ include::ROOT:partial$prometheus-activation.adoc[]
 
 == API Reference
 
-The xref:rest-api:rest_api_metric.adoc[API reference] groups all the endpoints by functionality.
-For more information, refer to xref:manage:stats-monitoring.adoc[View Statistics and Metrics].
+The {rest-api-metrics--xref--api-reference} groups all the endpoints by functionality.
+For more information, refer to {stats-monitoring--xref}.
 
 include::ROOT:partial$block-related-content-api.adoc[]

--- a/modules/rest-api/pages/rest-api.adoc
+++ b/modules/rest-api/pages/rest-api.adoc
@@ -14,6 +14,6 @@ include::ROOT:partial$_show_page_header_block.adoc[]
 
 == API Reference
 
-The xref:rest-api:rest_api_public.adoc[API reference] groups all the endpoints by functionality.
+The {rest-api--xref--api-reference} groups all the endpoints by functionality.
 
 include::ROOT:partial$block-related-content-api.adoc[]


### PR DESCRIPTION
Docs Issue: [DOC-13462](https://jira.issues.couchbase.com/browse/DOC-13462?atlOrigin=eyJpIjoiMDdlNDIzNTFhZDIxNDlkZWIxZDRmYjYxZjNiY2UzNzAiLCJwIjoiaiJ9)

PR to fix broken redocly links in 3.3 SGW 

Preview URL:

- [REST API admin](https://preview.docs-test.couchbase.com/docs-sync-gateway-DOC-13462-fix-broken-redocly-links/sync-gateway/current/rest-api/rest-api-admin.html)
- [Metrics REST API](https://preview.docs-test.couchbase.com/docs-sync-gateway-DOC-13462-fix-broken-redocly-links/sync-gateway/current/rest-api/rest-api-metrics.html)
- [Public REST API](https://preview.docs-test.couchbase.com/docs-sync-gateway-DOC-13462-fix-broken-redocly-links/sync-gateway/current/rest-api/rest-api.html)

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.

[DOC-13462]: https://couchbasecloud.atlassian.net/browse/DOC-13462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ