### PR TITLE
DOC-14180-restructure, add new explore page and cleanup text

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -15,6 +15,7 @@
 * xref:start-here:get-started-prepare.adoc[Prepare]
 * xref:start-here:get-started-install.adoc[Install]
 * xref:start-here:get-started-verify-install.adoc[Verify]
+* xref:start-here:get-started-explore.adoc[Explore]
 
 //
 

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -14,7 +14,7 @@
 // * xref:ROOT:index.adoc[Quick Links]
 * xref:start-here:get-started-prepare.adoc[Prepare]
 * xref:start-here:get-started-install.adoc[Install]
-* xref:start-here:get-started-verify-install.adoc[Verify]
+* xref:start-here:get-started-configure.adoc[Configure]
 * xref:start-here:get-started-explore.adoc[Explore]
 
 //

--- a/modules/ROOT/partials/_define_page_index.adoc
+++ b/modules/ROOT/partials/_define_page_index.adoc
@@ -268,9 +268,8 @@ endif::xref--pfx-sgw[]
 :get-started-prepare--config-server--xref: {get-started-prepare--pfx}#configure-server[Configure Server for Sync Gateway]
 :get-started-prepare--xref--create-rbac-users: {get-started-prepare--pfx}#step-2create-rbac-user[Create RBAC users]
 
-
-:get-started-verify-install--page:  start-here:get-started-verify-install.adoc
-:get-started-verify-install--xref: {sgw--xref}{get-started-verify-install--page}[Verify]
+:get-started-verify-install--page:  start-here:get-started-configure.adoc
+:get-started-verify-install--xref: {sgw--xref}{get-started-verify-install--page}[Configure]
 :get-started-explore--page:  start-here:get-started-explore.adoc
 :get-started-explore--xref: {sgw--xref}{get-started-explore--page}[Explore]
 

--- a/modules/ROOT/partials/_define_page_index.adoc
+++ b/modules/ROOT/partials/_define_page_index.adoc
@@ -271,6 +271,8 @@ endif::xref--pfx-sgw[]
 
 :get-started-verify-install--page:  start-here:get-started-verify-install.adoc
 :get-started-verify-install--xref: {sgw--xref}{get-started-verify-install--page}[Verify]
+:get-started-explore--page:  start-here:get-started-explore.adoc
+:get-started-explore--xref: {sgw--xref}{get-started-explore--page}[Explore]
 
 :glossary--page:  ROOT:glossary.adoc
 :glossary--xref: {sgw--xref}{glossary--page}[Glossary]

--- a/modules/start-here/pages/get-started-configure.adoc
+++ b/modules/start-here/pages/get-started-configure.adoc
@@ -142,7 +142,7 @@ TIP: If {sgw} is behind a load balancer, check the websockets configuration -- s
 
 == Next Steps
 
-Now that you have a verified {sgw} installation connected to {cbs}, continue to {get-started-explore--xref} page, where you'll add a database configuration, create users, and run a CRUD cycle to confirm sync is working end-to-end.
+Now that you have a configured {sgw} installation connected to {cbs}, continue to {get-started-explore--xref} page, where you'll add a database configuration, create users, and run a CRUD cycle to confirm sync is working end-to-end.
 
 From there, you can explore more complex scenarios with confidence:
 

--- a/modules/start-here/pages/get-started-configure.adoc
+++ b/modules/start-here/pages/get-started-configure.adoc
@@ -1,9 +1,9 @@
-= Verify a Sync Gateway Install
-:page-aliases: ROOT:start/get-started-verify-install.adoc
+= Configure a Sync Gateway Install
+:page-aliases: ROOT:start/get-started-verify-install.adoc, start-here:get-started-verify-install.adoc
 ifdef::show_edition[:page-edition: {release}]
 ifdef::prerelease[:page-status: {prerelease}]
 :page-role:
-:Description: pass:q[Configure and verify your _Sync Gateway_ installation; securely sync enterprise data from cloud to edge!]
+:Description: pass:q[Configure your _Sync Gateway_ installation; securely sync enterprise data from cloud to edge!]
 :page-type: procedural
 
 

--- a/modules/start-here/pages/get-started-explore.adoc
+++ b/modules/start-here/pages/get-started-explore.adoc
@@ -249,6 +249,7 @@ curl  --location --request GET 'http://localhost:4984/traveldb.inventory.hotel/h
 ----
 curl  --location -g \
       --request PUT 'http://localhost:4984/traveldb.inventory.hotel/hotel_88801?new_edits=true&rev=1-f28b5cc13a38892f4f85913d4e654270' \// <.>
+      --header "Authorization: Basic $DIGEST" \
       --header 'Accept: application/json' \
       --header 'Content-Type: application/json' \
       --data-raw '{
@@ -313,7 +314,8 @@ You should see the change you made in {cbs} reflected in the response. For examp
 .Request
 [{snippet-header}]
 ----
-curl --location -g --request DELETE 'http://localhost:4984/traveldb.inventory.hotel/hotel_88801?rev=3-cc2e758ef63b0daf5b01b2baf98c72b6' // <.>
+curl --location -g --request DELETE 'http://localhost:4984/traveldb.inventory.hotel/hotel_88801?rev=3-cc2e758ef63b0daf5b01b2baf98c72b6' \// <.>
+  --header "Authorization: Basic $DIGEST"
 ----
 <.> Provide the revision ID of the latest revision (3), as returned in the response to the last GET request.
 

--- a/modules/start-here/pages/get-started-explore.adoc
+++ b/modules/start-here/pages/get-started-explore.adoc
@@ -1,0 +1,369 @@
+= Explore Sync Gateway
+:page-topic-type: procedure
+:page-role:
+:description: pass:q[Add a database, create users, and run a CRUD cycle to explore your _Sync Gateway_ installation end-to-end.]
+:page-type: procedural
+
+
+include::ROOT:partial$_set_page_context.adoc[]
+
+
+// BEGIN - Page Attributes
+:xref--pfx: {sgw--xref}:
+// END - Page Attributes
+
+
+// BEGIN - Page Heading
+:topic-group: Start Here!
+:param-abstract: pass:q,a[This is *Step 4* in the _Start Here!_ topic group. Here we add a database configuration, create a {sgw} user, and run a CRUD cycle to confirm sync is working end-to-end.]
+include::ROOT:partial$_show_page_header_block.adoc[]
+// END - Page Heading
+
+
+.Preparatory Steps
+NOTE: Ensure you have completed all steps in {get-started-prepare--xref}, {get-started-install--xref}, and {get-started-verify-install--xref} before proceeding.
+
+:param-page: {page-relative-src-path}
+include::ROOT:partial$topic-group-get-started.adoc[]
+
+
+== Introduction
+
+In this step you will use the {sgw} Admin REST API to add a database configuration pointing to the `travel-sample` bucket, create a role and user scoped to the `inventory.hotel` collection, and then run a full CRUD cycle to confirm that sync is working between {sgw} and {cbs}.
+
+On completion of this topic you will have confirmed end-to-end sync and will be ready to build on this foundation with confidence.
+
+[NOTE]
+====
+The `curl` commands on this page require basic authentication using the `sync_gateway` {cbs} RBAC user credentials created in {get-started-prepare--xref--create-rbac-users}.
+You can create the Base64 digest from your credentials as follows:
+
+[source,console]
+----
+DIGEST=`echo -n sync_gateway:password | base64`
+echo $DIGEST
+# c3luY19nYXRld2F5OnBhc3N3b3Jk
+
+curl --header "Authorization: Basic $DIGEST" ...
+----
+====
+
+
+== Add a Database Configuration
+
+Use the Admin REST API to add a database to your {sgw} cluster.
+
+The `curl` command shown in <<ex-add-sgw-db>> creates a `traveldb` database pointing to the {cbs} `travel-sample` bucket, scoped to the `inventory.hotel` collection.
+
+[#ex-add-sgw-db]
+.Add a Sync Gateway Database
+====
+[source, bash]
+----
+curl  --location --request PUT 'http://127.0.0.1:4985/traveldb/' \// <.>
+      --header "Authorization: Basic $DIGEST" \
+      --header 'Content-Type: application/json' \
+      --data-raw '{
+          "bucket": "travel-sample", // <.>
+          "scopes": {
+            "inventory": {
+              "collections": {
+                "hotel": {} // <.>
+              }
+            }
+          },
+          "index": {"num_replicas": 0} // <.>
+          }'
+----
+<.> Here we specify the name of the {sgw} database -- `traveldb`
+<.> Now we point `traveldb` at the {cbs} bucket `travel-sample`, which we created in {get-started-prepare--config-server--xref}
+<.> We scope the database to the `inventory.hotel` collection in the `travel-sample` bucket
+<.> Set to zero for this example database
+====
+
+
+== Add a Sync Gateway User
+
+Create a {sgw} role and user to allow secure access during replication on this {sgw} cluster.
+
+=== Add a Role
+
+The `curl` command shown in <<ex-add-role>> adds a role called `stdrole` with access to the `inventory.hotel` collection.
+
+[#ex-add-role]
+.Add a Sync Gateway Role
+====
+[source, bash]
+----
+curl  --location --request PUT 'http://127.0.0.1:4985/traveldb/_role/stdrole' \// <.>
+      --header "Authorization: Basic $DIGEST" \
+      --header 'Content-Type: application/json' \
+      --data-raw '{
+          "name": "stdrole",
+          "collection_access": {
+             "inventory": { // <.>
+                "hotel": {
+                    "admin_channels": ["newrolechannel"] // <.>
+                 }
+             }
+           }
+      }'
+----
+
+<.> Here we identify the {sgw} database -- `traveldb`, the action `_role`, and the role name `stdrole`.
+<.> Here we scope the role to the `inventory` scope and `hotel` collection in the `travel-sample` bucket.
+<.> Here we identify the channels accessible to users assigned this role; these will be used by the Sync Function to control access.
+====
+
+=== Add the User
+
+The `curl` command shown in <<ex-add-user>> adds a user called `sgwuser1`.
+
+[#ex-add-user]
+.Add a Sync Gateway User
+====
+[source, bash]
+----
+curl  --location -g --request POST 'http://localhost:4985/traveldb/_user/' \// <.>
+      --header 'Content-Type: application/json' \
+      --header "Authorization: Basic $DIGEST" \// <.>
+      --data-raw '{
+          "name": "sgwuser1", // <.>
+          "password": "passwordstring",
+          "admin_roles": ["stdrole"], // <.>
+          "collection_access": {
+             "inventory": { // <.>
+                "hotel": {
+                    "admin_channels": ["public"]
+                 }
+             }
+           }
+      }'
+----
+<.> Here we identify the {sgw} database -- `traveldb` and the required object `_user`
+<.> The credential in the Authorization header relates to the {sgw} admin user
+<.> Here we provide the credentials of the user to create: name `sgwuser1` and required password.
+If the password is omitted, a random password is generated.
+<.> Here we identify any roles assigned to this user; it will inherit any channels associated with those roles.
+<.> Here we scope the user's access to the `inventory` scope and `hotel` collection in the `travel-sample` bucket.
+====
+
+
+== Verify the CRUD Cycle
+
+Here we will use curl and {sgw}'s REST API to run a full CRUD cycle:
+
+. <<lbl-crud-crt>> -- Add a document via the API and verify it appears in {cbs}
+. <<lbl-crud-get>> -- Read the document back from {cbs} using the {sgw} API
+. <<lbl-crud-upd>> -- Update the document and observe the change in {cbs}
+. <<lbl-crud-upd-svr>> -- Update the document in {cbs} and check the change in {sgw}
+. <<lbl-crud-del>> -- Delete the document and verify its state in both {cbs} and {sgw}
+
+
+[#lbl-crud-crt]
+=== Create a New Document
+
+Use curl to add a new document to the `traveldb` database via the {sgw} public API.
+
+.Request
+[source,console]
+----
+DIGEST=`echo -n sgwuser1:passwordstring | base64`
+
+curl  --location --request PUT 'http://localhost:4984/traveldb.inventory.hotel/hotel_88801' \// <.>
+      --header "Authorization: Basic $DIGEST" \
+      --header 'Content-Type: application/json' \
+      --data-raw '{
+          "_id": "hotel_88801",
+          "id": "88801",
+          "type": "hotel",
+          "name": "Verify-Install Topic",
+          "address": "The Shambles",
+          "city": "Manchester",
+          "country": "United Kingdom"
+      }'
+----
+<.> The keyspace `traveldb.inventory.hotel` targets the `hotel` collection in the `inventory` scope of the `traveldb` database.
+
+[#lbl-crud-add-resp, reftext=Response to Add Document Request]
+.Response
+[{snippet-header}]
+----
+{"id":"hotel_88801",
+"ok":true,
+"rev":"1-f28b5cc13a38892f4f85913d4e654270"}
+----
+
+[#lbl-check-cbs, reftext=Check Document on Couchbase Server]
+.Check
+View the document in the {cbs} Admin Console to verify it synced from {sgw}.
+
+. Within the Admin Console, select *Buckets* and select btn:[Documents] to open the _Document Editor_ tab.
+
+. Within the _Document Editor_ tab:
++
+.. Enter `travel-sample` as _Bucket_
+.. Enter `inventory` as _Scope_
+.. Enter `hotel` as _Collection_
+.. Enter `id="88801"` as _{sqlpp} WHERE_ query
+.. kbd:[Enter]
++
+You will see the response shown in <<img-cbs-view>>.
+The document should include any changes made through {sgw}, including the initial create.
++
+[#img-cbs-view]
+.Couchbase Server Document Editor
+image::ROOT:cbs-view-first-doc.png[]
+
+
+[#lbl-crud-get]
+=== Get a Document Using the API
+
+.Request
+[{snippet-header}]
+----
+curl  --location --request GET 'http://localhost:4984/traveldb.inventory.hotel/hotel_88801' \
+      --header "Authorization: Basic $DIGEST"
+----
+
+.Response
+[{snippet-header}]
+----
+{
+    "_id": "hotel_88801",
+    "_rev": "1-f28b5cc13a38892f4f85913d4e654270",
+    "address": "The Shambles",
+    "city": "Manchester",
+    "country": "United Kingdom",
+    "id": "88801",
+    "name": "Verify-Install Topic",
+    "type": "hotel"
+}
+----
+
+[#lbl-crud-upd]
+=== Update a Document Using the API
+
+.Request
+[{snippet-header}]
+----
+curl  --location -g \
+      --request PUT 'http://localhost:4984/traveldb.inventory.hotel/hotel_88801?new_edits=true&rev=1-f28b5cc13a38892f4f85913d4e654270' \// <.>
+      --header 'Accept: application/json' \
+      --header 'Content-Type: application/json' \
+      --data-raw '{
+        "_id": "hotel_88801",
+        "id": "88801",
+        "type": "hotel",
+        "name": "Verify-Install Topic Updated", // <.>
+        "address": "The Shambles",
+        "city": "Manchester",
+        "country": "United Kingdom",
+        "email": "enquiries@hotel_88801.internet" // <.>
+      }'
+----
+<.> This revision is the one returned by the response to the initial PUT request -- see: <<lbl-crud-add-resp>>
+<.> Here we change the text of the _name_ field.
+<.> Here we add an _email_ field.
+
+[#lbl-crud-upd-resp, reftext=Response to Update Document Request]
+.Response
+[{snippet-header}]
+----
+{
+    "id": "hotel_88801",
+    "ok": true,
+    "rev": "2-249366b198e81f203d7ae9eb54376210"  // <.>
+}
+----
+
+<.> The revision shows this is the second change to the document. `"ok":true` indicates success.
+
+.Check
+<<lbl-check-cbs>> -- does the document contain the updated _name_ value?
+
+[#lbl-crud-upd-svr]
+=== Sync a Couchbase Server Change
+
+This confirms that changes made in {cbs} replicate back to {sgw}.
+
+. Within the {cbs} Document Editor:
+
+.. Retrieve `88801` if it is not currently displayed.
+Use `meta().id="hotel_88801"` as the query, with `travel-sample` as _Bucket_, `inventory` as _Scope_, and `hotel` as _Collection_.
+.. Edit the _email_ value to `reception@hotel_88801.internet`
+.. Edit the _name_ value to `Verify-Install Topic-Updated-In-Server`
+.. btn:[Save] the change.
+
+. In your terminal, use the API to get the document again -- see <<lbl-crud-get>>. +
+You should see the change you made in {cbs} reflected in the response. For example:
++
+[{snippet-header}]
+----
+{"_id":"hotel_88801","_rev":"3-cc2e758ef63b0daf5b01b2baf98c72b6", // <.>
+"address":"The Shambles","city":"Manchester","country":"United Kingdom","email":"reception@hotel_88801.internet","id":"88801","name":"Verify-Install Topic-Updated-In-Server","type":"hotel"}
+
+----
+<.> The revision sequence is now 3. The _email_ and _name_ fields reflect both the {sgw} change and the {cbs} amendment.
+
+
+[#lbl-crud-del]
+=== Delete a Document Using the API
+
+.Request
+[{snippet-header}]
+----
+curl --location -g --request DELETE 'http://localhost:4984/traveldb.inventory.hotel/hotel_88801?rev=3-cc2e758ef63b0daf5b01b2baf98c72b6' // <.>
+----
+<.> Provide the revision ID of the latest revision (3), as returned in the response to the last GET request.
+
+.Response
+[{snippet-header}]
+----
+{
+    "id": "hotel_88801",
+    "ok": true,
+    "rev": "4-03f1ba127340e8c50c31a36279298e60" // <.>
+}
+----
+<.> The delete counts as the fourth revision. `"ok":true` indicates success.
+
+.Check
+
+* <<lbl-check-cbs>> -- you should now see "No Results".
+
+* Use the API to get the document -- see: <<lbl-crud-get>>. +
+You should see the following response:
++
+[{snippet-header}]
+----
+{"error":"not_found","reason":"deleted"}%
+----
+
+
+== Ways to Verify Sync
+
+To verify that document changes have been replicated, you can:
+
+* Monitor the {sgw} revision number returned by the database endpoint (xref:rest-api:rest_api_public.adoc#tag/Database-Management/operation/get_db-[GET /\{db}/]).
+The revision number increments for every change on the {sgw} database.
+* Query a document by ID on the {sgw} REST API -- see <<lbl-check-cbs>>.
+Use xref:rest-api:rest_api_public.adoc#tag/Document/operation/get_keyspace-docid[GET /\{keyspace}/\{docid}] -- see: {rest-api-access--xref} for more.
+* Query a document from the Query Workbench on the {cbs} Console.
+
+
+== Next Steps
+
+Now you have confirmed {sgw} is deployed and syncing end-to-end.
+You can explore more complex scenarios with confidence.
+
+* Learn more about {sgw}'s {configuration-schema-bootstrap--xref} or how to {sync-with-couchbase-server--xref}
+* Implement access controls for users and data -- see: {users--xref}, {roles--xref}, and the {sync-function--xref}
+* Implement secure connectivity -- see: {authentication-users--xref} and {authentication-certs--xref}
+* Build more complex syncs:
+** Other {sgw} nodes -- see: {sync-inter-syncgateway-overview--xref}
+** Mobile devices using Couchbase Lite -- see: {sync-using-app--xref}
+
+// BEGIN -- Page Footer
+include::ROOT:partial$block-related-content-deploy.adoc[]
+// END -- Page Footer

--- a/modules/start-here/pages/get-started-explore.adoc
+++ b/modules/start-here/pages/get-started-explore.adoc
@@ -78,7 +78,7 @@ curl  --location --request PUT 'http://127.0.0.1:4985/traveldb/' \// <.>
 <.> Here we specify the name of the {sgw} database -- `traveldb`
 <.> Now we point `traveldb` at the {cbs} bucket `travel-sample`, which we created in {get-started-prepare--config-server--xref}
 <.> We scope the database to the `inventory.hotel` collection in the `travel-sample` bucket
-<.> Set to zero for this example database
+<.> Suitable for single-node development clusters -- remove or increase for production
 ====
 
 

--- a/modules/start-here/pages/get-started-install.adoc
+++ b/modules/start-here/pages/get-started-install.adoc
@@ -53,13 +53,13 @@ For other command-line options -- see {command-line-options--xref}
 
 // BEGIN -- Page Heading
 :topic-group: Start Here!
-:param-abstract: pass:q[This is *Step 3* in the _Start Here!_ topic group. It installs the _Sync Gateway_ binary distribution]
+:param-abstract: pass:q[This is *Step 2* in the _Start Here!_ topic group. It installs the _Sync Gateway_ binary distribution]
 
 include::ROOT:partial$_show_page_header_block.adoc[]
 // END -- Page Heading
 
 .Preparatory Steps
-NOTE: Ensure you have read -- and acted-upon -- the information in {get-started-prepare--xref}.
+NOTE: Make sure you have read and acted-upon the information in {get-started-prepare--xref} before proceeding.
 
 :param-page: {page-relative-src-path}
 include::ROOT:partial$topic-group-get-started.adoc[]
@@ -600,33 +600,23 @@ For Mac OS this will be the `.plist` file `com.couchbase.mobile.sync_gateway.pli
 . Ensure the new file path includes a useable Sync Gateway configuration file
 . Within a terminal, stop the service -- see: <<lbl-macos-run, start and stop the service>>
 . Copy the existing `com.couchbase.mobile.sync_gateway.plist` file to a safe location as a back-up
-. Open the `com.couchbase.mobile.sync_gateway.plist` file in an editor. You will need to use `sudo`
+. Open the `com.couchbase.mobile.sync_gateway.plist` file in an editor. You'll need to use `sudo`
 . Within the `ProgramArguments` section of the `.plist`, find and edit the configuration file path, which by default contains:
 `<string>/Users/sync_gateway/sync_gateway.json</string>`
 . Save your changes
 . Restart the service  -- see: <<lbl-macos-run, start and stop the service>>
 
 
-== Check the Install
-To check Sync Gateway started successfully, you can now connect to it from a browser by using either:
-
-* http://localhost:4984[http://localhost:4984] for the Public API
-* http://localhost:4985[http://localhost:4985] for the Admin API
-
-You should receive a response in the browser such as: +
-`{"couchdb":"Welcome","vendor":{"name":"Couchbase Sync Gateway","version":"{version}"},"version":"Couchbase Sync Gateway/\{version-maintenance}(145;e3f46be) EE"}`
-
-If you do encounter issues in getting an operational install of Sync Gateway, you can find some useful information in the log files. Refer to the {logging--xref} page for how to configure different logging levels to aid troubleshooting.
-
 == Next Steps
-Now that you have a working version of Sync Gateway, which you can connect a console to using either the Public or Admin REST API, you can:
 
-* Verify and explore the sync functionality using -- {get-started-verify-install--xref}
+Now that you have installed Sync Gateway, continue to verify and explore the installation:
+
+* {get-started-verify-install--xref} -- configure {sgw} to connect to {cbs} and verify the connection
+* {get-started-explore--xref} -- add a database, create users, and run a CRUD cycle to confirm sync end-to-end
 * Learn more about building Couchbase Mobile applications using the {url-tutorial-mobile-workshop} tutorial
-* Learn more about the sync process
+* Learn more about the sync process:
 ** {sync-with-couchbase-server--xref}
 ** {configuration-schema-bootstrap--xref}
-
 
 
 include::ROOT:partial$block-related-content-deploy.adoc[]

--- a/modules/start-here/pages/get-started-prepare.adoc
+++ b/modules/start-here/pages/get-started-prepare.adoc
@@ -21,7 +21,7 @@ include::ROOT:partial$_set_page_context.adoc[]
 
 // BEGIN -- Page Heading
 :topic-group: Start Here!
-:param-abstract: pass:q[This is *Step 2* in the _Start Here!_ topic group. It introduces the prerequisites for the installation of _Sync Gateway_]
+:param-abstract: pass:q[This is *Step 1* in the _Start Here!_ topic group. It introduces the prerequisites for installing _Sync Gateway_]
 
 include::ROOT:partial$_show_page_header_block.adoc[]
 // END -- Page Heading
@@ -31,10 +31,10 @@ include::ROOT:partial$topic-group-get-started.adoc[]
 
 == What You Need
 
-Here's what you need in order to install Sync Gateway:
+Here's what you need to install Sync Gateway:
 
 * To know whether your set-up meets the <<lbl-req-minim>> and <<lbl-req-compat>> for running Sync Gateway
-* To have access to a working Couchbase Server deployment configured for Sync Gateway, or alternatively, to know how to {server-install-get-started--xref}
+* To have access to a working Couchbase Server deployment configured for Sync Gateway or know how to {server-install-get-started--xref}
 * To <<configure-server>>, including creating an appropriate set of RBAC users, ready for use in Sync Gateway and in the REST API
 * Have appropriate network credentials and <<lbl-set-netw-access, Network Access>>
 
@@ -44,11 +44,11 @@ Once you have all that covered ... go {get-started-install--xref} {sgw-t}.
 == Couchbase Server Requirements
 
 To use Sync Gateway you need an operational Couchbase Server installation.
-Ensure that you use compatible versions of Couchbase Server and Sync Gateway -- see: <<lbl-req-compat>>.
+Verify that you use compatible versions of Couchbase Server and Sync Gateway -- see: <<lbl-req-compat>>.
 
-TIP: You can get Couchbase Server from our {url-downloads}[Downloads, window=_blank] page
+TIP: You can get Couchbase Server from the {url-downloads}[Downloads, window=_blank] page
 
-You will then need to configure Couchbase Server by adding a Bucket and an RBAC User for Sync Gateway -- see: <<configure-server>>.
+You'll then need to configure Couchbase Server by adding a Bucket and an RBAC User for Sync Gateway -- see: <<configure-server>>.
 
 include::ROOT:partial$block-caveats.adoc[tags="cbs6.0ke-xattrs"]
 
@@ -149,13 +149,13 @@ NOTE: For more on creating Couchbase Server users see: {server-manage-security-u
 [#lbl-set-netw-access]
 === Step {counter: step} -- Set-up Network Access
 
-When installing Couchbase Server on the cloud, ensure that network permissions (or firewall settings) allow incoming connections to Couchbase Server ports.
+When installing Couchbase Server on the cloud, make sure that network permissions (or firewall settings) allow incoming connections to Couchbase Server ports.
 
 include::ROOT:partial$sgw-svr-ports.adoc[]
 
 If this is not done, the Couchbase Server node can experience difficulty joining a cluster.
 
-You can refer to the {xref--pfx-svr}install:install-ports.adoc[Couchbase Server Ports] guide to see the full list of available ports and their associated services.
+For more information, see the {xref--pfx-svr}install:install-ports.adoc[Couchbase Server Ports] guide to see the full list of available ports and their associated services.
 
 // BEGIN -- Page Footer
 include::ROOT:partial$block-related-content-deploy.adoc[]

--- a/modules/start-here/pages/get-started-verify-install.adoc
+++ b/modules/start-here/pages/get-started-verify-install.adoc
@@ -20,16 +20,16 @@ include::ROOT:partial$_set_page_context.adoc[]
 
 // BEGIN - Page Heading
 :topic-group: Start Here!
-:param-abstract: pass:q,a[This is *Step 4* in the _Start Here!_ topic group. Here we will verify that you can connect your _{sgw}_ to a _Couchbase Server_ and synchronize changes whether made in Couchbase Server or through {sgw}'s REST API.]
+:param-abstract: pass:q,a[This is *Step 3* in the _Start Here!_ topic group. Here you'll configure _{sgw}_ to connect to a _Couchbase Server_ instance and verify that the connection is working.]
 include::ROOT:partial$_show_page_header_block.adoc[]
 // END - Page Heading
 
 
 .Preparatory Steps
-NOTE: Ensure you have read, and acted-upon, the information and steps in {get-started-prepare--xref} and {get-started-install--xref}
+NOTE: Make sure you have read and acted-upon the information and steps in {get-started-prepare--xref} and {get-started-install--xref} before proceeding.
 
 These instructions are for local or server based deployments.
-If you are using a container such as Docker, see this
+If you're using a container such as Docker, see this
 https://blog.couchbase.com/using-docker-with-couchbase-mobile/[blog post on using Docker with Couchbase Mobile] for additional details.
 
 
@@ -39,26 +39,25 @@ include::ROOT:partial$topic-group-get-started.adoc[]
 
 == Introduction
 
+In this step of the Getting Started topic we will configure your {sgw-te} to connect to a {cbs-te} instance and verify that the connection is working.
 
-In this final step of the Getting Started topic we will look to link your {sgw-te} to a {cbs-te} bucket and verify that sync is taking place by executing a CRUD cycle.
-You will need to edit the configuration file used in the {get-started-install--xref} step to point to a bucket on your {cbs} -- see <<lbl-config>>.
+You'll need to edit the configuration file used in the {get-started-install--xref} step to point to a bucket on your {cbs} -- see <<lbl-config>>.
 
-On completion of this topic you will have a working {sgw} instance that you know syncs with a {cbs}.
-You will have successfully completed installation and can now build on this with confidence.
+On completion of this topic you'll have a working {sgw} instance connected to {cbs}.
+You can then continue to {get-started-explore--xref} to add a database, create users, and run a CRUD cycle.
 
 
 [#lbl-config]
 == Bootstrap Sync Gateway
 
-
 To configure {sgw} to connect to a {cbs}:
 
-. Ensure your {sgw} service is stopped/unloaded
+. Make sure your {sgw} service stops/unloads
 . Edit the configuration file you used in {get-started-install--xref} and replace the contents with those shown in <<sample-cfg>>.
 +
-The configuration points to your {cbs} cluster, which we will use to verify that you can synchronize changes made through the {sgw} API with those made through {cbs}.
-. Ensure you start {cbs}
-. Restart/Load your {sgw}  to pick-up the changed configuration
+The configuration points to your {cbs} cluster, which you'll use to verify that you can connect to {cbs} through {sgw}.
+. Make sure you start {cbs}
+. Restart/Load your {sgw} to pick-up the changed configuration
 
 
 [#sample-cfg]
@@ -89,18 +88,20 @@ The configuration points to your {cbs} cluster, which we will use to verify that
 
 About the Configuration Properties:
 
-<.> Here we point to the {cbs} cluster using secure connection. Server ships with self signed certs that work out of the box, as long as `server_tls_skip_verify` is set, as it is below.
+<.> Here you'll point to the {cbs} cluster using secure connection.
+Server ships with self-signed certs that work out of the box, as long as `server_tls_skip_verify` is set, as it's below.
 
-<.> Here we provide the credentials for the RBAC user that you created on the {cbs} Admin Console -- see {get-started-prepare--config-server--xref}
+<.> Here you'll provide the credentials for the RBAC user that you created on the {cbs} Admin Console -- see {get-started-prepare--config-server--xref}
 
-<.> Here we opt to ignore CA Cert verification of the certificate presented by the server; allowing for example use of self-signed certificate. The connection is unverified but encrypted.
+<.> Here you'll opt to ignore CA Cert verification of the certificate presented by the server; allowing for example use of self-signed certificate.
+The connection is unverified but encrypted.
 
-<.> Optionally, you can choose to run without TLS, by setting this value `false`.
+<.> Optionally, you can choose to run without TLS by setting this value to `false`.
 In that case you should also use the plaintext URI `couchbase://localhost` to connect.
 
-<.> Define your logging requirements: +
-Here we set general diagnostic console logs on.
-If you're having issues then refer to {logging--xref} for how to tune diagnostics to provide additional troubleshooting help
+<.> Define your logging requirements. +
+Here you'll set general diagnostic console logs on.
+If you're having issues, for more information, see {logging--xref} for how to tune diagnostics to provide additional troubleshooting help.
 
 ====
 
@@ -111,12 +112,11 @@ Run the following in a terminal:
 ----
 bin/sync_gateway -<options> sgwconfig.json // <.>
 ----
-<.> Optionally provide any CLI flags you require to use
+<.> Optionally provide any CLI flags you require to use.
 
 == Connect to Sync Gateway
 
-
-TIP: You can use {xref-sgw-bmk-logging-console} to aid diagnosis of connection issues
+TIP: You can use {xref-sgw-bmk-logging-console} to aid diagnosis of connection issues.
 
 . With {sgw} and {cbs} started, point your browser to the {sgw} url, typically on port 4984, but this can be changed -- see: {rest-api-access--xref}.
 +
@@ -134,353 +134,22 @@ http://localhost:4984
 {"couchdb":"Welcome","vendor":{"name":"Couchbase Sync Gateway","version":"{version}"},"version":"Couchbase {sgw}/\{version-full}(376;e2e7d42) EE"}
 ----
 +
-If there are issues then check the {xref-sgw-bmk-logging-console} for more information.
+If there are issues, check the {xref-sgw-bmk-logging-console} for more information.
 Where necessary you can redirect console output to a file -- see: {xref-sgw-bmk-logging-console-redirect}.
 
-TIP: If {sgw} is behind a load balancer then check the websockets configuration -- see {load-balancer--xref}.
-
-== Add a Database Configuration
-
-
-We can now use the Admin REST API to add a database to our {sgw} cluster.
-
-[NOTE]
-====
-The `curl` commands on this page requires basic authentication using the `api_admin` {cbs} RBAC user's credentials we created in Step 2 of {get-started-prepare--xref--create-rbac-users}.
-You can create the digest by taking a Base64 of `username:password`. For example:
-
-[source,console]
-----
-DIGEST=`echo -n sync_gateway:password | base64`
-echo $DIGEST
-# c3luY19nYXRld2F5OnBhc3N3b3Jk
-
-curl --header "Authorization: Basic $DIGEST" ...
-----
-====
-
-The `curl` command shown in <<ex-add-sgw-db>> below a `traveldb` database pointing to the {cbs}'s `travel-sample` bucket.
-
-[#ex-add-sgw-db]
-.Add a Sync Gateway Database
-====
-[source, bash]
-----
-curl  --location --request PUT 'http://127.0.0.1:4985/traveldb/' \// <.>
-      --header "Authorization: Basic $DIGEST" \
-      --header 'Content-Type: application/json' \
-      --data-raw '{
-          "bucket": "travel-sample", // <.>
-          "index": {"num_replicas": 0} // <.>
-          }'
-----
-<.> Here we specify the name of the {sgw} database -- `traveldb`
-<.> Now we point `traveldb` at the {cbs} bucket `travel-sample`, which we created in {get-started-prepare--config-server--xref}
-<.> Set to zero for this example database
-// <.> Here we specify the {sgw} `users` able to access the databaseintroduces a guest user with access to all channels and all documents
-====
-
-
-== Add a Sync Gateway User
-
-
-We can now create a {sgw} user and role to allow secure access during replication on this {sgw} cluster.
-
-=== Add a role
-
-The `curl` command shown in <<ex-add-role>> requires basic authentication using the `api_admin` {cbs} RBAC user's credentials we created in Step 2 of {get-started-prepare--xref--create-rbac-users}.
-It adds a role called `stdrole`.
-
-[#ex-add-role]
-.Add a Sync Gateway Role
-====
-[source, bash]
-----
-curl  --location --request PUT 'http://127.0.0.1:4985/traveldb/_role/stdrole' \// <.>
-      --header "Authorization: Basic $DIGEST" \
-      --header 'Content-Type: application/json' \
-      --data-raw '{
-          "name": "stdrole",
-          "collection_access": {
-             "scopename": {
-                "collection_name" {
-                    admin_channels": ["newrolechannel"] // <.>
-                 }
-             }
-           }
-      }'
-----
-
-<.> Here we identify the name of the {sgw} database -- `traveldb` +
-The action, `_role` and +
-The role's name `stdrole`
-
-<.> Now we identify the channels accessible to users assigned this role; these will be used by the Sync Function to control access.
-
-====
-
-=== Add the user
-
-The `curl` command shown in <<ex-add-user>> requires basic authentication using the `api_admin` {cbs} RBAC user's credentials we created in Step 2 of {get-started-prepare--xref--create-rbac-users}.
-It adds a user called `sgwuser1`.
-
-[#ex-add-user]
-.Add a Sync Gateway User
-====
-[source, bash]
-----
-curl  --location -g --request POST 'http://localhost:4985/traveldb/_user/' \// <.>
-      --header 'Content-Type: application/json' \
-      --header "Authorization: Basic $DIGEST" \// <.>
-      --data-raw '{
-          "name": "sgwuser1", // <.>
-          "password": "passwordstring",
-          "admin_roles": ["stdrole"], // <.>
-          "collection_access": {
-             "scopename": {
-                "collection_name" {
-                    admin_channels": ["public"] // <.>
-                 }
-             }
-           }
-      }'
-----
-<.> Here we identify the name of the {sgw} database -- `traveldb` and the required object, `_user`
-<.> The user/password credential represented in the _Authorization_ header relate to the Sync Gateway admin user
-<.> Here we give the credentials of the user we want to create. So, the user's name `sgwuser1` and required password.
-If we omit the password a random password is generated.
-<.> Now we identify any roles accessible to this user; it will inherit any channels associated with the role(s).
-<.> Now we identify any channels accessible to this user, in addition to those inherited from the role; these will be used by the Sync Function to control access.
-
-====
-
-== Verify the CRUD Cycle
-
-Here we will use CURL and {sgw}'s REST API to
-
-. <<lbl-crud-crt>> Use the API to add a document and check the document on {cbs}
-
-. <<lbl-crud-get>> Read the document back from {cbs} using the {sgw} API
-
-. <<lbl-crud-upd>> Update the newly created document and observe the changes in {cbs}
-
-. <<lbl-crud-upd-svr>> Update the document in Couchase Server and check the change in {sgw}
-
-. <<lbl-crud-del>> Delete our document and check its state on {cbs} and {sgw}.
-
-Remember to use the credentials of the {cbs} RBAC user for authentication.
-
-
-[#ex-sync]
-
-[#lbl-crud-crt]
-=== Create a New Document:
-
-Within a terminal use CURL to issue the following POST request, which adds a new document to the {cbs} bucket `get-started-bucket` by way of the {sgw} database `get-started-bucket` we configured in <<lbl-config>>
-
-.Request
-[source,console]
-----
-DIGEST=`echo -n sgwuser1:password | base64`
-
-curl  --location --request PUT 'http://localhost:4984/traveldb/hotel_88801' \
-      --header "Authorization: Basic $DIGEST" \
-      --header 'Content-Type: application/json' \
-      --data-raw '{
-          "_id": "hotel_88801",
-          "id": "88801",
-          "type": "hotel",
-          "name": "Verify-Install Topic",
-          "address": "The Shambles",
-          "city": "Manchester",
-          "country": "United Kingdom"
-      }'
-----
-
-[#lbl-crud-add-resp, reftext=Response to Add Document Request]
-.Response
-[{snippet-header}]
-----
-{"id":"hotel_88801",
-"ok":true,
-"rev":"1-f28b5cc13a38892f4f85913d4e654270"}
-----
-
-[#lbl-check-cbs, reftext=Check Document on Couchbase Server]
-.Check
-View the document in {cbs} Admin Console to verify it syncs from {sgw} database.
-
-. Within the Admin Console, select *Buckets* and hit the btn:[Documents] button to open the _Document Editor_ tab.
-
-. Within the _Document Editor_ tab:
-+
-.. Enter `travel-sample` as _Bucket_
-.. Leave _Scope_ and _Collection_ as `_default`
-.. Enter `id="88801"` as _{sqlpp} WHERE_ query
-.. kbd:[Enter]
-+
-You will see the response shown in <<img-cbs-view>>.
-The document should include any changes made through {sgw}, including the initial create.
-+
-[#img-cbs-view]
-.Couchbase Server Document Editor
-image::ROOT:cbs-view-first-doc.png[]
-
-
-[#lbl-crud-get]
-=== Get a Document Using the API:
-
-.Request
-[{snippet-header}]
-----
-curl  --location --request GET 'http://localhost:4984/traveldb/hotel_88801' \
-      --header "Authorization: Basic $DIGEST"
-----
-
-.Response
-[{snippet-header}]
-----
-{
-    "_id": "hotel_88801",
-    "_rev": "1-f28b5cc13a38892f4f85913d4e654270",
-    "address": "The Shambles",
-    "city": "Manchester",
-    "country": "United Kingdom",
-    "id": "88801",
-    "name": "Verify-Install Topic",
-    "type": "hotel"
-}
-----
-
-[#lbl-crud-upd]
-=== Update a Document using API:
-
-.Request
-[{snippet-header}]
-----
-curl  --location -g \
-      --request PUT 'http://localhost:4984/traveldb/hotel_88801?new_edits=true&rev=1-f28b5cc13a38892f4f85913d4e654270' \// <.>
-      --header 'Accept: application/json' \
-      --header 'Content-Type: application/json' \
-      --data-raw '{
-        "_id": "hotel_88801",
-        "id": "88801",
-        "type": "hotel",
-        "name": "Verify-Install Topic Updated", // <.>
-        "address": "The Shambles",
-        "city": "Manchester",
-        "country": "United Kingdom",
-        "email": "enquiries@hotel_88801.internet" // <.>
-      }'
-----
-<.> This revision is the one returned by the response to the initial POST request -- see: <<lbl-crud-add-resp>>
-<.> Here we change the text of the _name_ field.
-<.> Here we add an _email_ field.
-
-[#lbl-crud-upd-resp, reftext=Response to Update Document Request]
-.Response
-[{snippet-header}]
-----
-{
-    "id": "hotel_88801",
-    "ok": true,
-    "rev": "2-249366b198e81f203d7ae9eb54376210"  // <.>
-}
-----
-
-<.> Here the `"ok":true` indicates success, whilst the revision shows it is the second change to this document.
-
-.Check
-<<lbl-check-cbs>>.
-Does the document contain the changed _data_ value?
-
-[#lbl-crud-upd-svr]
-=== Sync a Couchbase Server Change
-
-This will show that changes made using {cbs} are replicated to {sgw}.
-
-. Within the {cbs} Document Editor
-
-.. Retrieve `88801` if it is not currently displayed +
-Use `meta().id="hotel_88801"` as query
-.. Edit the _email_ value to contain `reception@hotel_88801.internet`
-.. Edit the _name_ value to contain `Verify-Install Topic-Updated-In-Server`
-.. btn:[Save] the change. +
-
-. In your terminal, use the API to get the document again -- see <<lbl-crud-get>> +
-You should see the change you made in {cbs} reflected in the response. For example:
-+
-[{snippet-header}]
-----
-{"_id":"hotel_88801","_rev":"3-cc2e758ef63b0daf5b01b2baf98c72b6", // <.>
-"address":"The Shambles","city":"Manchester","country":"United Kingdom","email":"reception@hotel_88801.internet","id":"88801","name":"Verify-Install Topic-Updated-In-Server","type":"hotel"}
-
-----
-<.> Note that the revision sequence is now 3, up from the 2 returned in our <<lbl-crud-upd-resp>>
-Note that the _email_ and _name_ fields now contains both the change made in {sgw} and the amendment made in {cbs} ("reception")
-
-
-[#lbl-crud-del]
-=== Delete a Document Using API
-
-.Request
-[{snippet-header}]
-----
-curl --location -g --request DELETE 'http://localhost:4984/traveldb/hotel_88801?rev=3-cc2e758ef63b0daf5b01b2baf98c72b6' // <.>
-----
-<.> Note that we provide the revision ID of the latest revision (3), as returned in the response to the last GET request.
-
-.Response
-You should see the following response:
-[{snippet-header}]
-----
-{
-    "id": "hotel_88801",
-    "ok": true,
-    "rev": "4-03f1ba127340e8c50c31a36279298e60" // <.>
-}
-----
-<.> The delete counts as the fourth change/revision.
-`"ok":true` indicates the delete was successful.
-
-.Check
-
-* <<lbl-check-cbs>> and you should now see "No Results"
-
-* Use the API to get the document -- see:  <<lbl-crud-get>>.
-Assuming the delete worked you should see the following response:
-+
-[{snippet-header}]
-----
-{"error":"not_found","reason":"deleted"}%
-----
-
-
-== Ways to Verify Sync
-
-
-To verify that document changes have been replicated, you can:
-
-* Monitor the {sgw} revision number returned by the database endpoint (xref:rest-api:rest_api_public.adoc#tag/Database-Management/operation/get_db-[GET /\{db}/]).
-The revision number increments for every change that happens on the {sgw} database.
-* Query a document by ID on the {sgw} REST API as shown in <<lbl-check-cbs>>. Use xref:rest-api:rest_api_public.adoc#tag/Document/operation/get_keyspace-docid[GET /\{keyspace}/\{docid}] -- see: {rest-api-access--xref} for more.
-* Query a document from the Query Workbench on the {cbs} Console.
+TIP: If {sgw} is behind a load balancer, check the websockets configuration -- see {load-balancer--xref}.
 
 
 == Next Steps
 
-Now you know {sgw} is deployed and operational.
-So, you can explore more complex scenarios with confidence.
+Now that you have a verified {sgw} installation connected to {cbs}, continue to {get-started-explore--xref} page, where you'll add a database configuration, create users, and run a CRUD cycle to confirm sync is working end-to-end.
 
-Maybe you want to learn more about {sgw}'s {configuration-schema-bootstrap--xref} or how to {sync-with-couchbase-server--xref}. Or perhaps you want to explore how to:
+From there, you can explore more complex scenarios with confidence:
 
-* Implement access controls for users and data -- see: {users--xref}, {roles--xref} and the {sync-function--xref} that ties it all together.
-
-* Implement secure connectivity using TLS/SSL, which is described in {authentication-users--xref} and {authentication-certs--xref}
-
-* Build more complex syncs, such as those that sync with:
-** Other {sgw} nodes, for which see {sync-inter-syncgateway-overview--xref}
-** Apps on mobile devices using Couchbase Lite -- see {sync-using-app--xref}
+* Learn more about {sgw}'s {configuration-schema-bootstrap--xref}
+* Learn how to {sync-with-couchbase-server--xref}
+* Implement access controls -- see: {users--xref}, {roles--xref}, and the {sync-function--xref}
+* Implement secure connectivity -- see: {authentication-users--xref} and {authentication-certs--xref}
 
 // BEGIN -- Page Footer
 include::ROOT:partial$block-related-content-deploy.adoc[]


### PR DESCRIPTION
Docs Issue: [DOC-14180](https://jira.issues.couchbase.com/browse/DOC-14180?atlOrigin=eyJpIjoiODQ0YzY3ZmY1NzNiNGY1Zjk1MzhlZmMxNzc4NzBjNGIiLCJwIjoiaiJ9)

PR to restructure the getting starte pages of Sync Gateway, introduce an Explore page for next steps after verify 

Preview URL:
https://preview.docs-test.couchbase.com/docs-sync-gateway-DOC-14180-restructure-quick-start-guide

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.

[DOC-14180]: https://couchbasecloud.atlassian.net/browse/DOC-14180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ