### PR TITLE
DOC-14280-add docker for sgw

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -12,8 +12,11 @@
 
 .Start Here!
 // * xref:ROOT:index.adoc[Quick Links]
+
+.Start Here!
 * xref:start-here:get-started-prepare.adoc[Prepare]
 * xref:start-here:get-started-install.adoc[Install]
+* xref:start-here:get-started-install-docker.adoc[Deploy with Docker]
 * xref:start-here:get-started-configure.adoc[Configure]
 * xref:start-here:get-started-explore.adoc[Explore]
 

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -15,8 +15,8 @@
 
 .Start Here!
 * xref:start-here:get-started-prepare.adoc[Prepare]
-* xref:start-here:get-started-install.adoc[Install]
 * xref:start-here:get-started-install-docker.adoc[Deploy with Docker]
+* xref:start-here:get-started-install.adoc[Install]
 * xref:start-here:get-started-configure.adoc[Configure]
 * xref:start-here:get-started-explore.adoc[Explore]
 

--- a/modules/start-here/pages/get-started-configure.adoc
+++ b/modules/start-here/pages/get-started-configure.adoc
@@ -29,8 +29,7 @@ include::ROOT:partial$_show_page_header_block.adoc[]
 NOTE: Make sure you have read and acted-upon the information and steps in {get-started-prepare--xref} and {get-started-install--xref} before proceeding.
 
 These instructions are for local or server based deployments.
-If you're using a container such as Docker, see this
-https://blog.couchbase.com/using-docker-with-couchbase-mobile/[blog post on using Docker with Couchbase Mobile] for additional details.
+If you're using Docker, see xref:start-here:get-started-install-docker.adoc[Deploy Sync Gateway with Docker] instead.
 
 
 :param-page: {page-relative-src-path}

--- a/modules/start-here/pages/get-started-install-docker.adoc
+++ b/modules/start-here/pages/get-started-install-docker.adoc
@@ -57,9 +57,9 @@ Run {cbs} in a Docker container on the `couchbase` network.
 ----
 docker run -d --name cb-server \
   --network couchbase \
-  -p 8091-8094:8091-8094 \
-  -p 11210:11210 \
-  couchbase
+  -p 8091-8097:8091-8097 \
+  -p 11210-11211:11210-11211 \
+  couchbase/server
 ----
 
 === Configure Couchbase Server

--- a/modules/start-here/pages/get-started-install-docker.adoc
+++ b/modules/start-here/pages/get-started-install-docker.adoc
@@ -17,7 +17,7 @@ include::ROOT:partial$_set_page_context.adoc[]
 
 // BEGIN -- Page Heading
 :topic-group: Start Here!
-:param-abstract: pass:q[This is an alternative to *Steps 2 and 3* in the _Start Here!_ topic group. It deploys _{sgw}_ and _{cbs}_ using Docker containers.]
+:param-abstract: pass:q[This is an alternative to the *Install* and *Configure* steps in the _Start Here!_ topic group. It deploys _{sgw}_ and _{cbs}_ using Docker containers.]
 
 include::ROOT:partial$_show_page_header_block.adoc[]
 // END -- Page Heading

--- a/modules/start-here/pages/get-started-install-docker.adoc
+++ b/modules/start-here/pages/get-started-install-docker.adoc
@@ -185,7 +185,7 @@ docker stop sync-gateway
 docker rm sync-gateway
 ----
 
-Then repeat <<run_sync_gateway>>.
+Then repeat <<run-sync-gateway>>.
 
 
 == Next Steps

--- a/modules/start-here/pages/get-started-install-docker.adoc
+++ b/modules/start-here/pages/get-started-install-docker.adoc
@@ -1,0 +1,204 @@
+= Deploy Sync Gateway with Docker
+ifdef::show_edition[:page-edition: {release}]
+ifdef::prerelease[:page-status: {prerelease}]
+:page-role:
+:Description: pass:q[Deploy _Sync Gateway_ using Docker; securely sync enterprise data from cloud to edge.]
+:page-type: procedural
+
+
+include::ROOT:partial$_set_page_context.adoc[]
+
+
+// BEGIN -- Page Attributes
+:xref-pfx: {sgw--xref}:
+:xref-sgw-bmk-logging-console: xref:{sgw-pg-logging}#lbl-console-logs[Console Logs]
+// END -- Page Attributes
+
+
+// BEGIN -- Page Heading
+:topic-group: Start Here!
+:param-abstract: pass:q[This is an alternative to *Steps 2 and 3* in the _Start Here!_ topic group. It deploys _{sgw}_ and _{cbs}_ using Docker containers.]
+
+include::ROOT:partial$_show_page_header_block.adoc[]
+// END -- Page Heading
+
+.Preparatory Steps
+NOTE: Make sure you have read and acted-upon the information in {get-started-prepare--xref} before proceeding.
+
+:param-page: {page-relative-src-path}
+include::ROOT:partial$topic-group-get-started.adoc[]
+
+
+== Before You Begin
+
+Make sure you have:
+
+* Docker installed on your machine.
+See the https://docs.docker.com/get-docker/[Docker installation guide, window=_blank] for instructions.
+* The bucket name and RBAC credentials from {get-started-prepare--xref}.
+
+
+== Deploy Couchbase Server
+
+=== Create a Docker Network
+
+Create a Docker bridge network so that {cbs-te} and {sgw-te} containers can communicate.
+
+[{snippet-header}]
+----
+docker network create --driver bridge couchbase
+----
+
+=== Run Couchbase Server
+
+Run {cbs} in a Docker container on the `couchbase` network.
+
+[{snippet-header}]
+----
+docker run -d --name cb-server \
+  --network couchbase \
+  -p 8091-8094:8091-8094 \
+  -p 11210:11210 \
+  couchbase
+----
+
+=== Configure Couchbase Server
+
+Once {cbs} is running, open the Admin UI at `+http://localhost:8091+` and complete the setup described in {get-started-prepare--xref}, including:
+
+* Creating a cluster
+* Creating a bucket
+* Creating an RBAC user for {sgw}
+
+NOTE: Note the bucket name and RBAC credentials. You will need them in the next step.
+
+
+== Deploy Sync Gateway
+
+=== Create a Configuration File
+
+Create a configuration file named `sync-gateway-config.json` on your local machine.
+
+Replace `<rbac-username>` and `<rbac-password>` with the credentials you set up in {cbs}.
+
+[#sample-cfg]
+.Sync Gateway Bootstrap Config for Docker
+====
+
+[source, json]
+----
+{
+  "bootstrap": {
+    "server": "couchbase://cb-server", // <.>
+    "username": "<rbac-username>", // <.>
+    "password": "<rbac-password>",
+    "use_tls_server": false // <.>
+  },
+  "logging": {
+    "console": {
+      "enabled": true,
+      "log_level": "info",
+      "log_keys": ["*"]
+    }
+  }
+}
+----
+
+<.> Use the {cbs} container name `cb-server` as the hostname.
+Docker resolves this name within the `couchbase` network.
+
+<.> Use the RBAC credentials you created when you configured {cbs}.
+
+<.> TLS is disabled for local development.
+For production deployments, enable TLS and use `couchbases://cb-server` instead.
+
+====
+
+=== Run Sync Gateway
+
+Run {sgw} in a Docker container, mounting the configuration file you created.
+
+Replace `/path/to/sync-gateway-config.json` with the absolute path to the file on your local machine.
+
+[{snippet-header}]
+----
+docker run -d --name sync-gateway \
+  --network couchbase \
+  -p 4984-4985:4984-4985 \
+  -v /path/to/sync-gateway-config.json:/etc/sync_gateway/config.json \
+  couchbase/sync-gateway \
+  /etc/sync_gateway/config.json
+----
+
+NOTE: Port 4985 is the {sgw} Admin port. By default it is only accessible from within the container. Do not expose port 4985 to external traffic in production environments.
+
+
+== Verify the Connection
+
+. Point your browser to the {sgw} public port:
++
+[{snippet-header}]
+----
+http://localhost:4984
+----
+
+. Confirm that you receive a response similar to this:
++
+[{snippet-header}]
+----
+{"couchdb":"Welcome","vendor":{"name":"Couchbase Sync Gateway","version":"{version}"},"version":"Couchbase {sgw}/{version-full} EE"}
+----
++
+If there are issues, select the {xref-sgw-bmk-logging-console} for more information.
+
+
+== Manage Your Containers
+
+=== Stop Containers
+
+[{snippet-header}]
+----
+docker stop sync-gateway
+docker stop cb-server
+----
+
+=== Start Containers
+
+Start {cbs} before {sgw}.
+
+[{snippet-header}]
+----
+docker start cb-server
+docker start sync-gateway
+----
+
+NOTE: If {cbs} is stopped for an extended period, {sgw} loses the connection.
+Restart {sgw} after restarting {cbs}.
+
+=== Update the Sync Gateway Configuration
+
+To update the {sgw} configuration, stop and remove the container, then re-run it with the updated configuration file.
+
+[{snippet-header}]
+----
+docker stop sync-gateway
+docker rm sync-gateway
+----
+
+Then repeat <<run_sync_gateway>>.
+
+
+== Next Steps
+
+Now that you have {sgw} running in Docker, continue to {get-started-explore--xref} to add a database configuration, create users, and run a CRUD cycle to confirm sync is working end-to-end.
+
+From there, you can explore more complex scenarios:
+
+* Learn more about {sgw}'s {configuration-schema-bootstrap--xref}
+* Learn how to {sync-with-couchbase-server--xref}
+* Implement access controls -- see: {users--xref}, {roles--xref}, and the {sync-function--xref}
+
+
+// BEGIN -- Page Footer
+include::ROOT:partial$block-related-content-deploy.adoc[]
+// END -- Page Footer

--- a/modules/start-here/pages/get-started-install.adoc
+++ b/modules/start-here/pages/get-started-install.adoc
@@ -600,7 +600,7 @@ To change the default configuration file path of an existing Sync Gateway servic
 For Mac OS this will be the `.plist` file `com.couchbase.mobile.sync_gateway.plist`.
 
 .One way to do this would be:
-. Ensure the new file path includes a useable Sync Gateway configuration file
+. Make sure the new file path includes a useable Sync Gateway configuration file
 . Within a terminal, stop the service -- see: <<lbl-macos-run, start and stop the service>>
 . Copy the existing `com.couchbase.mobile.sync_gateway.plist` file to a safe location as a back-up
 . Open the `com.couchbase.mobile.sync_gateway.plist` file in an editor. You'll need to use `sudo`

--- a/modules/start-here/pages/get-started-install.adoc
+++ b/modules/start-here/pages/get-started-install.adoc
@@ -61,6 +61,9 @@ include::ROOT:partial$_show_page_header_block.adoc[]
 .Preparatory Steps
 NOTE: Make sure you have read and acted-upon the information in {get-started-prepare--xref} before proceeding.
 
+These instructions are for local or server based deployments.
+If you're using Docker, see xref:start-here:get-started-install-docker.adoc[Deploy Sync Gateway with Docker] instead.
+
 :param-page: {page-relative-src-path}
 include::ROOT:partial$topic-group-get-started.adoc[]
 


### PR DESCRIPTION
Docs Issue: [DOC-14280](https://jira.issues.couchbase.com/browse/DOC-14280?atlOrigin=eyJpIjoiZWNjZmQ1Yjg0NjFhNDc2Y2I2ZDNhZjViNWEyZjRjN2YiLCJwIjoiaiJ9)

PR to add deploying SGW with docker to getting started page 

Preview URL:
https://preview.docs-test.couchbase.com/docs-sync-gateway-DOC-14280-get-started-docker/sync-gateway/current/start-here/get-started-install-docker.html

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.


[DOC-14280]: https://couchbasecloud.atlassian.net/browse/DOC-14280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ