### PR TITLE
DOC-14497-remove-sgw4.0.5-4.0.6

### DIFF
--- a/modules/ROOT/partials/release_notes/sync-gateway-4-0-7-release-notes.adoc
+++ b/modules/ROOT/partials/release_notes/sync-gateway-4-0-7-release-notes.adoc
@@ -5,11 +5,18 @@ IMPORTANT: If you use Sync Gateway 4.0.5 or 4.0.6, upgrade to this release to re
 
 === Fixed Issues
 
+* https://jira.issues.couchbase.com/browse/CBG-5255[CBG-5255 -- Upgrading from non persistent config to persistent config will trigger database requiring resync]
+* https://jira.issues.couchbase.com/browse/CBG-5287[CBG-5287 -- _changes feeds with active_only=true and limit parameters can miss expected changes with revocations]
+* https://jira.issues.couchbase.com/browse/CBG-5361[CBG-5361 -- Panic in revoked feed handling]
+* https://jira.issues.couchbase.com/browse/CBG-5368[CBG-5368 -- Problem with channel removal macro expansion when channel names have `.` in them]
+* https://jira.issues.couchbase.com/browse/CBG-5383[CBG-5383 -- Resync regenerate sequences will not set _default metadata id when finished]
+* https://jira.issues.couchbase.com/browse/CBG-5453[CBG-5453 -- Subdoc operation failure on multiple channel removal]
 * https://jira.issues.couchbase.com/browse/CBG-5553[CBG-5553 -- activeOnly replication can miss documents for channels over the pagination limit]
 
 === Enhancements
 
-None for this release.
+* https://jira.issues.couchbase.com/browse/CBG-5394[CBG-5394 -- REST endpoint for pruning document channel history]
+* https://jira.issues.couchbase.com/browse/CBG-5396[CBG-5396 -- REST endpoint for pruning user channel history]
 
 === Known Issues
 

--- a/modules/product-notes/pages/release-notes.adoc
+++ b/modules/product-notes/pages/release-notes.adoc
@@ -47,10 +47,6 @@ The migration to a 4.x configuration is a ONE WAY process -- see: {upgrading--xr
 [#maint-latest]
 include::ROOT:partial$release_notes/sync-gateway-4-0-7-release-notes.adoc[]
 
-include::ROOT:partial$release_notes/sync-gateway-4-0-6-release-notes.adoc[]
-
-include::ROOT:partial$release_notes/sync-gateway-4-0-5-release-notes.adoc[]
-
 include::ROOT:partial$release_notes/sync-gateway-4-0-4-release-notes.adoc[]
 
 include::ROOT:partial$release_notes/sync-gateway-4-0-1-release-note.adoc[]


### PR DESCRIPTION
Docs Issue: [DOC-14497](https://jira.issues.couchbase.com/browse/DOC-14497)

PR to remove the SGW 4.0.5 and 4.0.6 versions from docs 

Preview URL:
https://preview.docs-test.couchbase.com/docs-sync-gateway-DOC-14497-sgw-4-0-5-and-4-0-6

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.

[DOC-14497]: https://couchbasecloud.atlassian.net/browse/DOC-14497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ