### PR TITLE
DOC-14051-note-shared-bucket-access

### DIFF
--- a/modules/sync/pages/sync-with-couchbase-server.adoc
+++ b/modules/sync/pages/sync-with-couchbase-server.adoc
@@ -153,6 +153,9 @@ The sync metadata includes the `_sync` extended attribute (XATTR) in use case do
 Shared bucket access is an opt-in feature.
 You can enable it without bringing down the entire {sgw-t} cluster  -- see <<enable-sba>>.
 
+WARNING: Enabling shared bucket access on your existing deployment is *not* reversible.
+We recommend testing the upgrade on a staging environment before upgrading the production environment.
+
 [#enable-sba]
 .Enable Bucket-Sharing
 ====


### PR DESCRIPTION
Docs Issue: [DOC-14051](https://jira.issues.couchbase.com/browse/DOC-14051?atlOrigin=eyJpIjoiZTQwZmEyNjc1MmMxNDY3NmJmOTU3MWUyZjFiNWZhZjQiLCJwIjoiaiJ9)

PR to update note shared access as one way migration 

Preview URL:
https://preview.docs-test.couchbase.com/docs-sync-gateway-DOC-14051-note-shared-bucket-access

Preview URL:
https://preview.docs-test.couchbase.com/docs-sync-gateway-note-shared-bucket-access

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.

[DOC-14051]: https://couchbasecloud.atlassian.net/browse/DOC-14051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ