### PR TITLE
DOC-14555-add-4.0.5-and-4.0.6-to-docs

### DIFF
--- a/modules/ROOT/partials/release_notes/sync-gateway-4-0-5-release-notes.adoc
+++ b/modules/ROOT/partials/release_notes/sync-gateway-4-0-5-release-notes.adoc
@@ -17,7 +17,7 @@ None for this release
 
 === Known Issues
 
-None for this release.
+* https://jira.issues.couchbase.com/browse/CBG-5554[CBG-5554 -- activeOnly replication can miss documents for channels over the pagination limit]
 
 === Deprecations
 

--- a/modules/ROOT/partials/release_notes/sync-gateway-4-0-5-release-notes.adoc
+++ b/modules/ROOT/partials/release_notes/sync-gateway-4-0-5-release-notes.adoc
@@ -1,7 +1,6 @@
 == 4.0.5 -- June 2026
 
-IMPORTANT: This release introduced fixes for OIDC-based authentication for deployments and managing users through the Sync Gateway Admin REST API.
-However, users of this release should upgrade to Sync Gateway 4.0.7 or later to receive critical fixes.
+WARNING: This version has a known issue, https://jira.issues.couchbase.com/browse/CBG-5554[CBG-5554 -- activeOnly replication can miss documents for channels over the pagination limit]. Please upgrade to Sync Gateway 4.1.1 or later 4.0.7 or later to receive critical fixes.
 
 [#maint-4-0-5]
 === Fixed Issues

--- a/modules/ROOT/partials/release_notes/sync-gateway-4-0-6-release-notes.adoc
+++ b/modules/ROOT/partials/release_notes/sync-gateway-4-0-6-release-notes.adoc
@@ -1,6 +1,6 @@
 == 4.0.6 -- June 2026
 
-IMPORTANT: Users of this release should upgrade to Sync Gateway 4.0.7 or later to receive critical fixes.
+WARNING: This version has a known issue, https://jira.issues.couchbase.com/browse/CBG-5554[CBG-5554 -- activeOnly replication can miss documents for channels over the pagination limit]. Please upgrade to Sync Gateway 4.1.1 or later 4.0.7 or later to receive critical fixes.
 
 [#maint-4-0-6]
 === Fixed Issues

--- a/modules/ROOT/partials/release_notes/sync-gateway-4-0-6-release-notes.adoc
+++ b/modules/ROOT/partials/release_notes/sync-gateway-4-0-6-release-notes.adoc
@@ -14,7 +14,7 @@ WARNING: This version has a known issue, https://jira.issues.couchbase.com/brows
 
 === Known Issues
 
-None for this release.
+* https://jira.issues.couchbase.com/browse/CBG-5554[CBG-5554 -- activeOnly replication can miss documents for channels over the pagination limit]
 
 === Deprecations
 

--- a/modules/product-notes/pages/release-notes.adoc
+++ b/modules/product-notes/pages/release-notes.adoc
@@ -47,6 +47,10 @@ The migration to a 4.x configuration is a ONE WAY process -- see: {upgrading--xr
 [#maint-latest]
 include::ROOT:partial$release_notes/sync-gateway-4-0-7-release-notes.adoc[]
 
+include::ROOT:partial$release_notes/sync-gateway-4-0-6-release-notes.adoc[]
+
+include::ROOT:partial$release_notes/sync-gateway-4-0-5-release-notes.adoc[]
+
 include::ROOT:partial$release_notes/sync-gateway-4-0-4-release-notes.adoc[]
 
 include::ROOT:partial$release_notes/sync-gateway-4-0-1-release-note.adoc[]


### PR DESCRIPTION
Docs Issue: [DOC-14555](https://jira.issues.couchbase.com/browse/DOC-14555)

PR to add the release 4.0.5 and 4.0.6 to the release notes 

Preview URL:
https://preview.docs-test.couchbase.com/docs-sync-gateway-DOC-14555-add-4.0.5-and-4.0.6-to-docs

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.

[DOC-14555]: https://couchbasecloud.atlassian.net/browse/DOC-14555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ